### PR TITLE
Support additional browser backends + refactoring

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -1,18 +1,21 @@
 # do nothing if Cucumber is not being used
 if defined?(Cucumber::RbSupport::RbDsl)
   require 'capybara/cucumber'
+  require 'capybara-screenshot/cucumber'
   
   After do |scenario|
-    screenshot_path = Capybara::Screenshot::Saver.screen_shot_and_save_page(Capybara, Capybara.body)[:image]
-    # Trying to embed the screenshot into our output."
-    if File.exist?(screenshot_path)
-      require "base64"
-      #encode the image into it's base64 representation
-      encoded_img = Base64.encode64(IO.read(screenshot_path))
-      #this will embed the image in the HTML report, embed() is defined in cucumber
-      embed("data:image/png;base64,#{encoded_img}", 'image/png', "Screenshot of the error")
-    else
-      puts "Screenshot not found #{screenshot_path}"
+    if scenario.failed?
+      screenshot_path = Capybara::Screenshot::Cucumber.screen_shot_and_save_page[:image]
+      # Trying to embed the screenshot into our output."
+      if File.exist?(screenshot_path)
+        require "base64"
+        #encode the image into it's base64 representation
+        encoded_img = Base64.encode64(IO.read(screenshot_path))
+        #this will embed the image in the HTML report, embed() is defined in cucumber
+        embed("data:image/png;base64,#{encoded_img}", 'image/png', "Screenshot of the error")
+      else
+        puts "Screenshot not found #{screenshot_path}"
+      end
     end
   end
 end

--- a/lib/capybara-screenshot/cucumber.rb
+++ b/lib/capybara-screenshot/cucumber.rb
@@ -2,8 +2,8 @@ require 'capybara-screenshot/saver'
 
 module Capybara
   module Screenshot
-    module World
-      def screen_shot_and_save_page
+    module Cucumber
+      def self.screen_shot_and_save_page
         Capybara::Screenshot::Saver.screen_shot_and_save_page Capybara, Capybara.body
       end
     end

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -2,10 +2,13 @@ module Capybara
   module Screenshot
     module Saver
       def self.screen_shot_and_save_page(capybara, body)        
+        #Our default return values
+        html_path = nil
+        image_path = nil
+        
         if capybara.current_path.to_s.empty?
           puts "Current path is empty, can't take a screenshot"
         else
-          puts "Trying to take a screenshot for #{capybara.current_path}."
           require 'capybara/util/save_and_open_page'
           file_base_name = "#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}"
           #will save to the capybara.save_and_open_page_path
@@ -22,9 +25,8 @@ module Capybara
             #screenshot_path = File.join(capybara.save_and_open_page_path.to_s, "#{file_base_name}.png")
             screenshot_path = "#{file_base_name}.png"
           end
-          
-          puts "Saving the screenshot as #{screenshot_path}."
             
+          #We try to figure out how to call the screenshot method on the current driver
           case capybara.current_driver
           when :poltergeist
             capybara.page.driver.render(screenshot_path, :full => true)


### PR DESCRIPTION
This is a "large" change and some of the refactorings might be somewhat opinionated.
This allows people to test on non-rails projects (e.g. when testing external webapps) using the selenium/capybara-webkit/poltergeist drivers.

I hope I didn't break any of the non-cucumber or rails related things.

Cheers,
Marc
