### PR TITLE
Support for Padrino

### DIFF
--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -17,7 +17,9 @@ module Capybara
           #where should we save the screenshot to
           if defined?(Rails)
             screenshot_path = Rails.root.join "#{capybara.save_and_open_page_path}/#{file_base_name}.png"
-          elsif defined?(Sinatra) and !defined?(Padrino) # settings will be nil for Padrino apps
+          elsif defined?(Padrino)
+            screenshot_path = Padrino.root "#{capybara.save_and_open_page_path}/#{file_base_name}.png"
+          elsif defined?(Sinatra)
             # Sinatra support, untested
             screenshot_path = File.join(settings.root, "#{capybara.save_and_open_page_path}/#{file_base_name}.png")
           else


### PR DESCRIPTION
Simple gem, well executed, thanks!

Here's a patch to support Padrino. Since Padrino is built on Sinatra, the Sinatra check succeeds, but then the settings variable is nil, and the app tanks.

This just makes a check with Padrino, then uses the Padrino root method. 

Note, it doesn't quite operate the same as the Rails.root, (see https://github.com/padrino/padrino-framework/issues/730) but what I have checked in works.

H
