### PR TITLE
Set screenshot filename via env variable

### DIFF
--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -5,7 +5,7 @@ module Capybara
 
       def initialize(capybara, page, html_save=true)
         @capybara, @page, @html_save = capybara, page, html_save
-        @file_base_name = "screenshot-#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}"
+        @file_base_name = ENV['screenshot_name'] || "screenshot-#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}"
       end
 
       def save


### PR DESCRIPTION
In this pull request, I add the ability to read from ENV['screenshot_name'] as an option for setting the file_base_name in the Saver class.  If the environment variable is not set, it defaults to your timestamp filename pattern.
