### PR TITLE
Set safe default for save_and_open_page_path

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -33,8 +33,8 @@ module Capybara
 
     def self.capybara_root
       return @capybara_root if defined?(@capybara_root)
-
-      capybara_tmp_path = Capybara.save_and_open_page_path.to_s
+      #If the path isn't set, default to the current directory
+      capybara_tmp_path = Capybara.save_and_open_page_path || '.'
 
       @capybara = if defined?(Rails)
         Rails.root.join capybara_tmp_path


### PR DESCRIPTION
otherwise we might end up at /screenshot[...].png directly in the root folder which we don't have permissions for
