### PR TITLE
Add a screenshot driver for rack_test which is a noop

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -64,6 +64,10 @@ Capybara::Screenshot.class_eval do
     driver.render(path)
   end
 
+  register_driver(:rack_test) do |driver, path|
+    warn "Rack::Test capybara driver has no ability to output screen shots. Skipping."
+  end
+
   register_driver(:selenium) do |driver, path|
     driver.browser.save_screenshot(path)
   end 


### PR DESCRIPTION
Avoids errors when using Rack::Test to output a screenshot using default, when we know it can't.
