### PR TITLE
Add screen shots to Capybara::DSL so they automatically get added to Cucumber world and RSpec request specs

### DIFF
--- a/capybara-screenshot.gemspec
+++ b/capybara-screenshot.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "capybara-screenshot"
 
   s.add_dependency 'capybara', '>= 1.0'
-  s.add_development_dependency 'rspec', '~> 2.6'
+  s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'timecop'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -85,6 +85,7 @@ Capybara::Screenshot.class_eval do
 end
 
 require 'capybara-screenshot/saver'
+require 'capybara-screenshot/capybara'
 
 # do nothing if Cucumber is not being used
 if defined?(Cucumber::RbSupport::RbDsl)

--- a/lib/capybara-screenshot/capybara.rb
+++ b/lib/capybara-screenshot/capybara.rb
@@ -1,0 +1,14 @@
+module Capybara
+  module DSL
+    # Adds class methods to Capybara module and gets mixed into
+    # the current scope during Cucumber and RSpec tests
+
+    def screen_shot_and_save_page
+      Capybara::Screenshot.screen_shot_and_save_page
+    end
+
+    def screen_shot_and_open_image
+      Capybara::Screenshot.screen_shot_and_open_image
+    end
+  end
+end

--- a/lib/capybara-screenshot/cucumber.rb
+++ b/lib/capybara-screenshot/cucumber.rb
@@ -1,20 +1,3 @@
-module Capybara
-  module Screenshot
-    module Cucumber
-
-      def screen_shot_and_save_page
-        Capybara::Screenshot.screen_shot_and_save_page
-      end
-
-      def screen_shot_and_open_image
-        Capybara::Screenshot.screen_shot_and_open_image
-      end
-      
-    end
-  end
-end
-World(Capybara::Screenshot::Cucumber)
-
 After do |scenario|
   if Capybara::Screenshot.autosave_on_failure && scenario.failed?
     filename_prefix = Capybara::Screenshot.filename_prefix_for(:cucumber, scenario)

--- a/spec/capybara-screenshot/capybara_spec.rb
+++ b/spec/capybara-screenshot/capybara_spec.rb
@@ -1,0 +1,16 @@
+module Capybara::Screenshot
+	describe Capybara do
+    
+    it 'should add screen shot methods to the Capybara module' do
+      ::Capybara.should respond_to(:screen_shot_and_save_page)
+      ::Capybara.should respond_to(:screen_shot_and_open_image)
+    end
+
+    context 'request type example', :type => :request do
+      it 'should have access to screen shot instance methods' do
+        self.should respond_to(:screen_shot_and_save_page)
+        self.should respond_to(:screen_shot_and_open_image)
+      end
+    end
+	end
+end


### PR DESCRIPTION
The Capybara::DSL is the module that contains the methods which get included where the capybara DSL methods are needed. Removes the need to do this in each test type ourselves.
