### PR TITLE
make capy-screenshot work w/ steak, which uses type :acceptance

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -1,12 +1,14 @@
 RSpec.configure do |config|
-  config.after(:type => :request) do
-    if Capybara::Screenshot.autosave_on_failure && example.exception
-      filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)
+  config.after(:each) do
+    if [:request, :acceptance].include?(example.metadata[:type])
+      if Capybara::Screenshot.autosave_on_failure && example.exception
+        filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)
 
-      saver = Capybara::Screenshot::Saver.new(Capybara, Capybara.page, true, filename_prefix)
-      saver.save
+        saver = Capybara::Screenshot::Saver.new(Capybara, Capybara.page, true, filename_prefix)
+        saver.save
 
-      example.metadata[:full_description] += "\n     Screenshot: #{saver.screenshot_path}"
+        example.metadata[:full_description] += "\n     Screenshot: #{saver.screenshot_path}"
+      end
     end
   end
 end


### PR DESCRIPTION
Steak uses type :acceptance instead of :request, so I changed the RSpec after hook to fire screenshots under either type of spec.
