### PR TITLE
Rename screen_shot to screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ can be more useful if you disable the auto-generate on failure feature with the 
 
 Anywhere the Capybara DSL methods (visit, click etc.) are available so too will are the screenshot methods.
 
-	screen_shot_and_save_page
+	screenshot_and_save_page
 
 Or for screenshot only, which will automatically open the image.
 
-	screen_shot_and_open_image
+	screenshot_and_open_image
 
 These are just calls on the main library methods.
 
-	Capybara::Screenshot.screen_shot_and_save_page
+	Capybara::Screenshot.screenshot_and_save_page
 
-	Capybara::Screenshot.screen_shot_and_open_image
+	Capybara::Screenshot.screenshot_and_open_image
 
 
 Driver configuration

--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -10,19 +10,24 @@ module Capybara
     self.registered_drivers = {}
     self.filename_prefix_formatters = {}
 
-    def self.screen_shot_and_save_page
+    def self.screenshot_and_save_page
       saver = Saver.new(Capybara, Capybara.page)
       saver.save
       {:html => saver.html_path, :image => saver.screenshot_path}
     end
 
-    def self.screen_shot_and_open_image
+    def self.screenshot_and_open_image
       require "launchy"
 
       saver = Saver.new(Capybara, Capybara.page, false)
       saver.save
       Launchy.open saver.screenshot_path
       {:html => saver.html_path, :image => saver.screenshot_path}
+    end
+
+    class << self
+      alias screen_shot_and_save_page screenshot_and_save_page
+      alias screen_shot_and_open_image screenshot_and_open_image
     end
 
     def self.filename_prefix_for(test_type, test)

--- a/lib/capybara-screenshot/capybara.rb
+++ b/lib/capybara-screenshot/capybara.rb
@@ -3,12 +3,12 @@ module Capybara
     # Adds class methods to Capybara module and gets mixed into
     # the current scope during Cucumber and RSpec tests
 
-    def screen_shot_and_save_page
-      Capybara::Screenshot.screen_shot_and_save_page
+    def screenshot_and_save_page
+      Capybara::Screenshot.screenshot_and_save_page
     end
 
-    def screen_shot_and_open_image
-      Capybara::Screenshot.screen_shot_and_open_image
+    def screenshot_and_open_image
+      Capybara::Screenshot.screenshot_and_open_image
     end
   end
 end

--- a/spec/capybara-screenshot/capybara_spec.rb
+++ b/spec/capybara-screenshot/capybara_spec.rb
@@ -4,14 +4,14 @@ module Capybara::Screenshot
 	describe Capybara do
 
     it 'should add screen shot methods to the Capybara module' do
-      ::Capybara.should respond_to(:screen_shot_and_save_page)
-      ::Capybara.should respond_to(:screen_shot_and_open_image)
+      ::Capybara.should respond_to(:screenshot_and_save_page)
+      ::Capybara.should respond_to(:screenshot_and_open_image)
     end
 
     context 'request type example', :type => :request do
       it 'should have access to screen shot instance methods' do
-        self.should respond_to(:screen_shot_and_save_page)
-        self.should respond_to(:screen_shot_and_open_image)
+        self.should respond_to(:screenshot_and_save_page)
+        self.should respond_to(:screenshot_and_open_image)
       end
     end
 	end


### PR DESCRIPTION
The gem's name would suggest that screenshot is used as one word, which it is, except for the `screen_shot_and_save_page` and `screen_shot_and_open_image` methods.

In this pull request I changed the screen_shot\* methods to screenshot\* and created a legacy alias to the old screen_shot\* methods.
