### PR TITLE
Make capybara-screenshot to work with the latest capybara-webkit

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -82,7 +82,11 @@ Capybara::Screenshot.class_eval do
   end
 
   register_driver(:webkit) do |driver, path|
-    driver.render(path)
+    if driver.respond_to?(:save_screenshot)
+      driver.save_screenshot(path)
+    else
+      driver.render(path)
+    end
   end
 
   register_driver(:webkit_debug) do |driver, path|

--- a/spec/capybara-screenshot/saver_spec.rb
+++ b/spec/capybara-screenshot/saver_spec.rb
@@ -138,10 +138,28 @@ describe Capybara::Screenshot::Saver do
       capybara_mock.stub(:current_driver).and_return(:webkit)
     end
 
-    it 'should save driver render' do
-      driver_mock.should_receive(:render).with(screenshot_path)
+    context 'has render method' do
+      before do
+        driver_mock.stub(:respond_to?).with(:'save_screenshot').and_return(false)
+      end
 
-      saver.save
+      it 'should save driver render' do
+        driver_mock.should_receive(:render).with(screenshot_path)
+
+        saver.save
+      end
+    end
+
+    context 'has save_screenshot method' do
+      before do
+        driver_mock.stub(:respond_to?).with(:'save_screenshot').and_return(true)
+      end
+
+      it 'should save driver render' do
+        driver_mock.should_receive(:save_screenshot).with(screenshot_path)
+
+        saver.save
+      end
     end
   end
 


### PR DESCRIPTION
At thoughtbot/capybara-webkit@32b92ad , Capybara::Webkit::Driver#render was renamed to #save_screenshot. I added a condition so that it would work with capybara-webkit master branch.
