### PR TITLE
Fixes #45

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -48,8 +48,7 @@ module Capybara
       elsif defined?(Padrino)
         Padrino.root capybara_tmp_path
       elsif defined?(Sinatra)
-        # Sinatra support, untested
-        File.join(settings.root, capybara_tmp_path)
+        File.join(Sinatra::Application.root, capybara_tmp_path)
       else
         capybara_tmp_path
       end.to_s


### PR DESCRIPTION
Fix for issue #45 

```
   undefined local variable or method `settings' for Capybara::Screenshot:Module (NameError)
```

after upgrading to the latest Sinatra.
