### PR TITLE
Bugfix: undefined method root for Capybara::Rails:Module

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -43,8 +43,8 @@ module Capybara
       #If the path isn't set, default to the current directory
       capybara_tmp_path = Capybara.save_and_open_page_path || '.'
 
-      @capybara = if defined?(Rails)
-        Rails.root.join capybara_tmp_path
+      @capybara = if defined?(::Rails)
+        ::Rails.root.join capybara_tmp_path
       elsif defined?(Padrino)
         Padrino.root capybara_tmp_path
       elsif defined?(Sinatra)


### PR DESCRIPTION
Bug using capybara-screenshot with minitest-rails-capybara.

Gemfile:
group :test do
# Pretty printed test output

gem 'turn', :require => false
gem 'minitest-rails', '>=0.9.1'
gem 'minitest-rails-capybara', '>=0.9.0'
gem 'poltergeist'
gem 'launchy'
gem 'capybara-screenshot'
end

undefined method root' for Capybara::Rails:Module
ExceptionNoMethodError' at:
capybara-screenshot/lib/capybara-screenshot.rb:47:in capybara_root'
capybara-screenshot/lib/capybara-screenshot/saver.rb:41:inscreenshot_path'
capybara-screenshot/lib/capybara-screenshot/saver.rb:33:in save_screenshot'
capybara-screenshot/lib/capybara-screenshot/saver.rb:17:insave'
capybara-screenshot/lib/capybara-screenshot.rb:25:in screenshot_and_open_image'
capybara-screenshot/lib/capybara-screenshot/capybara.rb:11:inscreenshot_and_open_image'
