### PR TITLE
Bugfix: Save html to `html_path` instead of `file_base_name`.

### DIFF
--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -19,11 +19,11 @@ module Capybara
 
       def save_html
         if Capybara::VERSION.match(/^\d+/)[0] == '1'
-          capybara.save_page(page.body, "#{file_base_name}.html")
+          capybara.save_page(page.body, "#{html_path}")
         else
-          capybara.save_page("#{file_base_name}.html")
+          capybara.save_page("#{html_path}")
         end
-        warn "Saved file #{file_base_name}"
+        warn "Saved file #{html_path}"
       end
 
       def save_screenshot

--- a/spec/capybara-screenshot/saver_spec.rb
+++ b/spec/capybara-screenshot/saver_spec.rb
@@ -37,7 +37,7 @@ describe Capybara::Screenshot::Saver do
     end
 
     it 'should have default format of "screenshot_Y-M-D-H-M-S.ms.html"' do
-      capybara_mock.should_receive(:save_page).with('body', "#{file_basename}.html")
+      capybara_mock.should_receive(:save_page).with('body', File.join(capybara_root, "#{file_basename}.html"))
 
       saver.save
     end
@@ -45,7 +45,7 @@ describe Capybara::Screenshot::Saver do
     it 'should use name argument as prefix' do
       saver = Capybara::Screenshot::Saver.new(capybara_mock, page_mock, true, 'custom-prefix')
 
-      capybara_mock.should_receive(:save_page).with('body', "custom-prefix_#{timestamp}.html")
+      capybara_mock.should_receive(:save_page).with('body', File.join(capybara_root, "custom-prefix_#{timestamp}.html"))
 
       saver.save
     end
@@ -57,7 +57,7 @@ describe Capybara::Screenshot::Saver do
     end
 
     it 'should have default format of "screenshot_Y-M-D-H-M-S.ms.html"' do
-      capybara_mock.should_receive(:save_page).with("#{file_basename}.html")
+      capybara_mock.should_receive(:save_page).with(File.join(capybara_root, "#{file_basename}.html"))
 
       saver.save
     end
@@ -65,7 +65,7 @@ describe Capybara::Screenshot::Saver do
     it 'should use name argument as prefix' do
       saver = Capybara::Screenshot::Saver.new(capybara_mock, page_mock, true, 'custom-prefix')
 
-      capybara_mock.should_receive(:save_page).with("custom-prefix_#{timestamp}.html")
+      capybara_mock.should_receive(:save_page).with(File.join(capybara_root, "custom-prefix_#{timestamp}.html"))
 
       saver.save
     end


### PR DESCRIPTION
I.e. honor `capybara_root` provided by the user. Without this
patch the HTML output is _always_ written to the current
working directory.
