### PR TITLE
Override screenshot filename via ENV['CAPYBARA_SCREENSHOT_FILENAME']

### DIFF
--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -6,7 +6,8 @@ module Capybara
       def initialize(capybara, page, html_save=true, filename_prefix='screenshot')
         @capybara, @page, @html_save = capybara, page, html_save
         time_now = Time.now
-        @file_base_name = "#{filename_prefix}_#{time_now.strftime('%Y-%m-%d-%H-%M-%S.')}#{'%03d' % (time_now.usec/1000).to_i}"
+        @file_base_name = ENV['CAPYBARA_SCREENSHOT_FILENAME'] ||\
+          "#{filename_prefix}_#{time_now.strftime('%Y-%m-%d-%H-%M-%S.')}#{'%03d' % (time_now.usec/1000).to_i}"
       end
 
       def save

--- a/spec/capybara-screenshot/saver_spec.rb
+++ b/spec/capybara-screenshot/saver_spec.rb
@@ -84,6 +84,14 @@ describe Capybara::Screenshot::Saver do
       saver.save
     end
 
+    it 'should accept filename-override from ENV["CAPYBARA_SCREENSHOT_FILENAME"]' do
+      ENV["CAPYBARA_SCREENSHOT_FILENAME"] = "foo"
+      driver_mock.should_receive(:render).with(/foo\.png$/)
+
+      saver.save
+      ENV["CAPYBARA_SCREENSHOT_FILENAME"] = nil
+    end
+
     it 'should use filename prefix argument as basename prefix' do
       saver = Capybara::Screenshot::Saver.new(capybara_mock, page_mock, true, 'custom-prefix')
       driver_mock.should_receive(:render).with(/#{capybara_root}\/custom-prefix_#{timestamp}\.png$/)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,3 +17,5 @@ RSpec.configure do |config|
 end
 
 Capybara.app = lambda { |env| [200, {}, ["OK"]] }
+
+ENV['CAPYBARA_SCREENSHOT_FILENAME'] = nil


### PR DESCRIPTION
A static filename (without timestamp) is desirable in local
development. We can point an image-viewer at it and set it
to auto-reload, which is not possible with a constantly
changing filename.
