### PR TITLE
Remove deprication warnings from rspec tests

### DIFF
--- a/spec/capybara-screenshot/saver_spec.rb
+++ b/spec/capybara-screenshot/saver_spec.rb
@@ -20,10 +20,10 @@ describe Capybara::Screenshot::Saver do
   let(:file_basename) { "screenshot_#{timestamp}" }
   let(:screenshot_path) { "#{capybara_root}/#{file_basename}.png" }
 
-  let(:driver_mock) { mock('Capybara driver').as_null_object }
-  let(:page_mock) { mock('Capybara session page', :body => 'body', :driver => driver_mock).as_null_object }
+  let(:driver_mock) { double('Capybara driver').as_null_object }
+  let(:page_mock) { double('Capybara session page', :body => 'body', :driver => driver_mock).as_null_object }
   let(:capybara_mock) {
-    mock(Capybara).as_null_object.tap do |m|
+    double(Capybara).as_null_object.tap do |m|
       m.stub(:current_driver).and_return(:default)
       m.stub(:current_path).and_return('/')
     end
@@ -113,7 +113,7 @@ describe Capybara::Screenshot::Saver do
     end
 
     it 'should save via browser' do
-      browser_mock = mock('browser')
+      browser_mock = double('browser')
       driver_mock.should_receive(:browser).and_return(browser_mock)
       browser_mock.should_receive(:save_screenshot).with(screenshot_path)
 

--- a/spec/capybara-screenshot_spec.rb
+++ b/spec/capybara-screenshot_spec.rb
@@ -37,7 +37,7 @@ describe Capybara::Screenshot do
 
   describe ".filename_prefix_for" do
     it 'should return "screenshot" for undefined formatter' do
-      Capybara::Screenshot.filename_prefix_for(:foo, mock('test')).should eq 'screenshot'
+      Capybara::Screenshot.filename_prefix_for(:foo, double('test')).should eq 'screenshot'
     end
   end
 end


### PR DESCRIPTION
Creating double objects using the `stub` and `mock` methods is now deprecated in favour of the `double` method. They all actually do the same thing. This reduces a lot of noise in the tests with a recent version of rspec.
