### PR TITLE
Patch for windows IO.read problem

### DIFF
--- a/lib/capybara-screenshot/cucumber.rb
+++ b/lib/capybara-screenshot/cucumber.rb
@@ -9,7 +9,8 @@ After do |scenario|
     if File.exist?(saver.screenshot_path)
       require "base64"
       #encode the image into it's base64 representation
-      encoded_img = Base64.encode64(IO.read(saver.screenshot_path))
+      image = open(saver.screenshot_path, 'rb') {|io|io.read}
+      encoded_img = Base64.encode64(image)
       #this will embed the image in the HTML report, embed() is defined in cucumber
       embed("data:image/png;base64,#{encoded_img}", 'image/png', "Screenshot of the error")
     end

--- a/lib/capybara-screenshot/version.rb
+++ b/lib/capybara-screenshot/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Screenshot
-    VERSION = "0.3.14"
+    VERSION = "0.3.15"
   end
 end


### PR DESCRIPTION
Provided bug fix for cucumber After hook in windows environments (Windows 7/Ruby193) not functioning correctly with IO.read() . Replaced with Kernel.open() instead.
