### PR TITLE
Provide option to disable timestamp in basename

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,17 @@ add another driver configuration like so
 Custom screenshot filename
 --------------------------
 
-If you want to control the screenshot filename for a specific test libarary, to inject the test name into it for example,
+If you want to control the screenshot filename for a specific test library, to inject the test name into it for example,
 you can override how the basename is generated for the file like so
 
 	  Capybara::Screenshot.register_filename_prefix_formatter(:rspec) do |example|
 	    "screenshot_#{example.description.gsub(' ', '-').gsub(/^.*\/spec\//,'')}"
 	  end
+
+By default capybara-screenshot will append a timestamp to the basename. If you want to disable this behavior set the following option:
+
+    Capybara::Screenshot.append_timestamp = false
+
 
 Custom screenshot directory
 --------------------------

--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -5,12 +5,14 @@ module Capybara
       attr_accessor :registered_drivers
       attr_accessor :filename_prefix_formatters
       attr_accessor :append_screenshot_path
+      attr_accessor :append_timestamp
     end
 
     self.autosave_on_failure = true
     self.registered_drivers = {}
     self.filename_prefix_formatters = {}
     self.append_screenshot_path = true
+    self.append_timestamp = true
 
     def self.screenshot_and_save_page
       saver = Saver.new(Capybara, Capybara.page)
@@ -73,7 +75,7 @@ Capybara::Screenshot.class_eval do
   register_driver(:rack_test) do |driver, path|
     warn "Rack::Test capybara driver has no ability to output screen shots. Skipping."
   end
-  
+
   register_driver(:mechanize) do |driver, path|
     warn "Mechanize capybara driver has no ability to output screen shots. Skipping."
   end

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -6,7 +6,9 @@ module Capybara
       def initialize(capybara, page, html_save=true, filename_prefix='screenshot')
         @capybara, @page, @html_save = capybara, page, html_save
         time_now = Time.now
-        @file_base_name = "#{filename_prefix}_#{time_now.strftime('%Y-%m-%d-%H-%M-%S.')}#{'%03d' % (time_now.usec/1000).to_i}"
+        timestamp = "#{time_now.strftime('%Y-%m-%d-%H-%M-%S.')}#{'%03d' % (time_now.usec/1000).to_i}"
+        @file_base_name = filename_prefix
+        @file_base_name = "#{@file_base_name}_#{timestamp}" if Capybara::Screenshot.append_timestamp
       end
 
       def save

--- a/spec/capybara-screenshot/saver_spec.rb
+++ b/spec/capybara-screenshot/saver_spec.rb
@@ -84,6 +84,15 @@ describe Capybara::Screenshot::Saver do
       saver.save
     end
 
+    it "should not append timestamp if append_timestamp is false " do
+      default_config = Capybara::Screenshot.append_timestamp
+      Capybara::Screenshot.append_timestamp = false
+      driver_mock.should_receive(:render).with(/screenshot.png$/)
+
+      saver.save
+      Capybara::Screenshot.append_timestamp = default_config
+    end
+
     it 'should use filename prefix argument as basename prefix' do
       saver = Capybara::Screenshot::Saver.new(capybara_mock, page_mock, true, 'custom-prefix')
       driver_mock.should_receive(:render).with(/#{capybara_root}\/custom-prefix_#{timestamp}\.png$/)


### PR DESCRIPTION
Allows the automatic appending of a timestamp to the basename to be disabled with:

``` ruby
Capybara::Screenshot.append_timestamp = false
```

The use case is that I'm using capybara-screenshot on [Nitrous.io](http://nitrous.io) (remote server) and since I can't open files or my browser programmatically from there I want to know that I can always find a screenshot of the latest failure at `http://myremoteserver.com:3000/tmp/screenshot.png` using the following settings:

``` ruby
Capybara.save_and_open_page_path = 'public/tmp'
Capybara::Screenshot.append_screenshot_path = false
Capybara::Screenshot.append_timestamp = false
```
