### PR TITLE
Explicitly pass example variable into after block for RSpec 3.0.0

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -1,6 +1,6 @@
 RSpec.configure do |config|
   # use the before hook to add an after hook that runs last
-  config.after do
+  config.after do |example|
     if Capybara.page.respond_to?(:save_page) # Capybara DSL method has been included for a feature we can snapshot
       if Capybara.page.current_url != '' && Capybara::Screenshot.autosave_on_failure && example.exception
         filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)


### PR DESCRIPTION
Let me know what you think. The problem I'm seeing is this one:

```
RSpec::Core::ExampleGroup#example is deprecated and will be removed
in RSpec 3. There are a few options for what you can use instead:

  - rspec-core's DSL methods (`it`, `before`, `after`, `let`, `subject`, etc)
    now yield the example as a block argument, and that is the recommended
    way to access the current example from those contexts.
  - The current example is now exposed via `RSpec.current_example`,
    which is accessible from any context.
  - If you can't update the code at this call site (e.g. because it is in
    an extension gem), you can use this snippet to continue making this
    method available in RSpec 2.99 and RSpec 3:

      RSpec.configure do |c|
        c.expose_current_running_example_as :example
      end

(Called from /Users/parndt/.gem/ruby/2.1.0/gems/capybara-screenshot-0.3.16/lib/capybara-screenshot/rspec.rb:6:in `block (2 levels) in <top (required)>')
```

The problem goes away with this patch but I'm not sure if the solution really is this simple.

Thanks!
