### PR TITLE
Make it compatible with RSpec 3.

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -1,6 +1,10 @@
 RSpec.configure do |config|
   # use the before hook to add an after hook that runs last
-  config.after do
+  config.after do |example_from_block_arg|
+
+    # RSpec 3 no longer defines `example`, but passes the example as block argument instead
+    example = respond_to?(:example) ? self.example : example_from_block_arg
+
     if Capybara.page.respond_to?(:save_page) # Capybara DSL method has been included for a feature we can snapshot
       if Capybara.page.current_url != '' && Capybara::Screenshot.autosave_on_failure && example.exception
         filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)


### PR DESCRIPTION
From the release notes of RSpec 3:

> Remove `RSpec::Core::ExampleGroup#example` and `RSpec::Core::ExampleGroup#running_example` methods. If you need access to the example (e.g. to get its metadata), use a block arg instead

I changed it in a way that still works with RSpec 2, too.
