### PR TITLE
Do not embed image into html output

### DIFF
--- a/lib/capybara-screenshot/cucumber.rb
+++ b/lib/capybara-screenshot/cucumber.rb
@@ -12,16 +12,6 @@ After do |scenario|
       saver = Capybara::Screenshot::Saver.new(Capybara, Capybara.page, true, filename_prefix)
       saver.save
       saver.output_screenshot_path
-
-      # Trying to embed the screenshot into our output."
-      if File.exist?(saver.screenshot_path)
-        require "base64"
-        #encode the image into it's base64 representation
-        image = open(saver.screenshot_path, 'rb') {|io|io.read}
-        encoded_img = Base64.encode64(image)
-        #this will embed the image in the HTML report, embed() is defined in cucumber
-        embed("data:image/png;base64,#{encoded_img}", 'image/png', "Screenshot of the error")
-      end
     end
   end
 end


### PR DESCRIPTION
On Circle CI, the logic result in error
File name too long @ rb_sysopen - data:image/png;base64,iVBORw0KG...

This is not very useful as well.
