### PR TITLE
Don't initialize a new Capybara::Session in after hook

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -47,7 +47,7 @@ module Capybara
         attr_accessor :add_link_to_screenshot_for_failed_examples
 
         def after_failed_example(example)
-          if Capybara.page.respond_to?(:save_page) # Capybara DSL method has been included for a feature we can snapshot
+          if example.example_group.include?(Capybara::DSL) # Capybara DSL method has been included for a feature we can snapshot
             Capybara.using_session(Capybara::Screenshot.final_session_name) do
               if Capybara.page.current_url != '' && Capybara::Screenshot.autosave_on_failure && example.exception
                 filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)

--- a/spec/unit/capybara-screenshot_rspec_spec.rb
+++ b/spec/unit/capybara-screenshot_rspec_spec.rb
@@ -4,11 +4,11 @@ describe Capybara::Screenshot::RSpec do
   describe '.after_failed_example' do
     context 'for a failed example in a feature that can be snapshotted' do
       before do
-        allow(Capybara.page).to receive(:save_page)
         allow(Capybara.page).to receive(:current_url).and_return("http://test.local")
         allow(Capybara::Screenshot::Saver).to receive(:new).and_return(mock_saver)
       end
-      let(:example) { double("example", exception: Exception.new, metadata: {}) }
+      let(:example_group) { Module.new.include(Capybara::DSL) }
+      let(:example) { double("example", exception: Exception.new, example_group: example_group, metadata: {}) }
       let(:mock_saver) do
         Capybara::Screenshot::Saver.new(Capybara, Capybara.page).tap do |saver|
           allow(saver).to receive(:save)

--- a/spec/unit/rspec_reporters/text_reporter_spec.rb
+++ b/spec/unit/rspec_reporters/text_reporter_spec.rb
@@ -42,7 +42,8 @@ describe Capybara::Screenshot::RSpec::TextReporter do
   end
 
   def example_failed_method_argument_double(metadata = {})
-    example = double("example", metadata: metadata)
+    example_group = Module.new.include(Capybara::DSL)
+    example = double("example", metadata: metadata, example_group: example_group)
     if ::RSpec::Core::Version::STRING.to_i <= 2
       example
     else


### PR DESCRIPTION
The current way that capybara-screenshot tests for the inclusion of `Capybara::DSL` will initialize a new `Capybara::Session` even in tests that don't use Capybara - e.g., model tests. We ran into this when we realized some plain ruby tests were booting up Capybara, Poltergeist and PhantomJS.

I switched the after hook to explicitly test for inclusion of the `Capybara::DSL` mixin, and fixed all the tests as ran through appraisal. This change is working successfully in our Rails 3.2 app with model + controller unit tests as well as integration tests on Capybara 2.4 and Poltergeist. Please let me know if there's a reason not to merge this change - as far as I can figure, it's safe to test for `Capybara::DSL` directly since there's no way to take screenshots if you aren't in a Capybara-powered test :)