### PR TITLE
Replacing colored by colorize

### DIFF
--- a/capybara-screenshot.gemspec
+++ b/capybara-screenshot.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     s.add_dependency 'capybara', ['>= 1.0', '< 3']
   end
   s.add_dependency 'launchy'
-  s.add_dependency 'colored'
+  s.add_dependency 'colorize'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'timecop'

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -5,7 +5,7 @@ if RUBY_PLATFORM =~ /win32/
     fail "win32console gem is required to output colorized messages, please add this to your Gemfile or install"
   end
 end
-require 'colored'
+require 'colorize'
 
 module Capybara
   module Screenshot

--- a/lib/capybara-screenshot/version.rb
+++ b/lib/capybara-screenshot/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Screenshot
-    VERSION = '1.0.4'
+    VERSION = '1.0.5'
   end
 end


### PR DESCRIPTION
Hey guys,

Looks like [colored](https://github.com/defunkt/colored) doesn't play nice when we've got any other gem depending on [colorize](https://github.com/fazibear/colorize).

It blows up with the following error:
```bash
.../gems/colored-1.2/lib/colored.rb:70:in `colorize': no implicit conversion of Hash into String (TypeError)
```

Considering colored is not being maintained (or at least it looks like it's not), I would suggest using colorize instead.

This pull also fixes https://travis-ci.org/mattheworiordan/capybara-screenshot/jobs/46012046