### PR TITLE
Fix for https://github.com/mattheworiordan/capybara-screenshot/issues/112

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -5,6 +5,7 @@ module Capybara
       attr_accessor :registered_drivers
       attr_accessor :filename_prefix_formatters
       attr_accessor :append_timestamp
+      attr_accessor :append_random
       attr_accessor :webkit_options
       attr_writer   :final_session_name
       attr_accessor :prune_strategy
@@ -14,6 +15,7 @@ module Capybara
     self.registered_drivers = {}
     self.filename_prefix_formatters = {}
     self.append_timestamp = true
+    self.append_random = false
     self.webkit_options = {}
     self.prune_strategy = :keep_all
 

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -17,6 +17,7 @@ module Capybara
         timestamp = "#{time_now.strftime('%Y-%m-%d-%H-%M-%S.')}#{'%03d' % (time_now.usec/1000).to_i}"
         @file_base_name = filename_prefix
         @file_base_name = "#{@file_base_name}_#{timestamp}" if Capybara::Screenshot.append_timestamp
+        @file_base_name = "#{@file_base_name}_#{SecureRandom.hex}" if Capybara::Screenshot.append_random
 
         Capybara::Screenshot.prune
       end


### PR DESCRIPTION
This is a fix for https://github.com/mattheworiordan/capybara-screenshot/issues/112 - this adds the option to tell the library to append a "random" value to the end of each screenshot.  This helps mitigate issues where time is frozen and therefore the timestamps are always the same.