### PR TITLE
Fix loading issue

### DIFF
--- a/lib/capybara-screenshot/cucumber.rb
+++ b/lib/capybara-screenshot/cucumber.rb
@@ -1,3 +1,5 @@
+require 'capybara-screenshot'
+
 After do |scenario|
   if Capybara::Screenshot.autosave_on_failure && scenario.failed?
     filename_prefix = Capybara::Screenshot.filename_prefix_for(:cucumber, scenario)


### PR DESCRIPTION
After having installed the gem and updated the `env.rb` file, running a feature were failing with the following error:

    uninitialized constant Capybara::Screenshot (NameError)
    /Users/guillaumehain/.rvm/gems/ree-1.8.7-2012.02/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:466:in `load_missing_constant'
    /Users/guillaumehain/.rvm/gems/ree-1.8.7-2012.02/gems/activesupport-2.3.18/lib/active_support/dependencies.rb:106:in `const_missing'
    /Users/guillaumehain/Developments/fundlook/vendor/cache/capybara-screenshot-4aaa3fc12fa1/lib/capybara-screenshot/cucumber.rb:2:in `After'

This patch fix the issue.