### PR TITLE
WIP: S3 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,30 @@ Capybara::Screenshot.prune_strategy = :keep_last_run
 Capybara::Screenshot.prune_strategy = { keep: 20 }
 ```
 
+Uploading to Amazon S3
+--------------------------
+
+Be default screenshots are stored on the local filesystem. If you want to store
+the assets on Amazon S3, you can configure that as follows:
+
+```ruby
+Capybara::Screenshot::S3.configure do |config|
+  config.access_key_id = "YOUR_ACCESS_KEY_ID"
+  config.secret_access_key = "YOUR_SECRET_ACCESS_KEY"
+
+  # bucket name - required. this can be a string or a Proc
+  config.bucket = "some-bucket"
+
+  # optionally, specify as folder in which to store the screenshots
+  # can be a string or a Proc
+  config.folder = ->{
+    if build_number = ENV["BUILD_NUMBER"]
+      "builds/#{build_number}"
+    end
+  }
+end
+```
+
 
 Information about screenshots in RSpec output
 ---------------------------------------------

--- a/capybara-screenshot.gemspec
+++ b/capybara-screenshot.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
     s.add_dependency 'capybara', ['>= 1.0', '< 3']
   end
   s.add_dependency 'launchy'
+  s.add_dependency 'aws-sdk', '~> 2.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'timecop'

--- a/lib/capybara-screenshot/cucumber.rb
+++ b/lib/capybara-screenshot/cucumber.rb
@@ -12,6 +12,7 @@ After do |scenario|
       saver = Capybara::Screenshot::Saver.new(Capybara, Capybara.page, true, filename_prefix)
       saver.save
       saver.output_screenshot_path
+      Capybara::Screenshot::S3.flush if Capybara::Screenshot.upload_to_s3?
 
       # Trying to embed the screenshot into our output."
       if File.exist?(saver.screenshot_path)

--- a/lib/capybara-screenshot/minitest.rb
+++ b/lib/capybara-screenshot/minitest.rb
@@ -20,6 +20,11 @@ module Capybara::Screenshot::MiniTestPlugin
       end
     end
   end
+
+  def after_tests
+    super
+    Capybara::Screenshot::S3.flush if Capybara::Screenshot.upload_to_s3?
+  end
 end
 
 class MiniTest::Unit::TestCase

--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -56,8 +56,8 @@ module Capybara
                 saver.save
 
                 example.metadata[:screenshot] = {}
-                example.metadata[:screenshot][:html]  = saver.html_path if saver.html_saved?
-                example.metadata[:screenshot][:image] = saver.screenshot_path if saver.screenshot_saved?
+                example.metadata[:screenshot][:html]  = saver.html_location if saver.html_saved?
+                example.metadata[:screenshot][:image] = saver.screenshot_location if saver.screenshot_saved?
               end
             end
           end
@@ -88,5 +88,9 @@ RSpec.configure do |config|
         formatter.singleton_class.send :include, reporter_module
       end
     end
+  end
+
+  config.after(:suite) do
+    Capybara::Screenshot::S3.flush if Capybara::Screenshot.upload_to_s3?
   end
 end

--- a/lib/capybara-screenshot/s3.rb
+++ b/lib/capybara-screenshot/s3.rb
@@ -1,0 +1,90 @@
+require 'rubygems'
+require 'aws-sdk-core'
+
+module Capybara
+  module Screenshot
+    module S3
+      class << self
+        def configure(&block)
+          @uploader = Uploader.new
+          @uploader.instance_eval(&block)
+          unless @uploader.bucket_name
+            raise "Capybara::Screenshot::S3 - You must specify a bucket for S3 uploads"
+          end
+          Capybara::Screenshot.upload_to_s3 = true
+          @paths_to_upload = []
+        end
+
+        def flush
+          @paths_to_upload.each { |path| @uploader.upload(path) }
+          @paths_to_upload = []
+        end
+
+        def enqueue(path)
+          @paths_to_upload << path
+        end
+
+        def url_for(path)
+          @uploader.url_for(path)
+        end
+
+        def upload(path)
+          @uploader.upload(path)
+        end
+
+        class Uploader
+          attr_writer :access_key_id
+          attr_writer :bucket
+          attr_writer :folder
+          attr_writer :region
+          attr_writer :secret_access_key
+
+          def upload(path)
+            key = File.basename(path)
+            key = File.join(folder, key) if folder
+
+            client.put_object(bucket: bucket, key: key, body: IO.read(path), acl: "public-read")
+          end
+
+          def bucket_name
+            @bucket
+          end
+
+          def client
+            @client ||= Aws::S3::Client.new(client_options)
+          end
+
+          def client_options
+            options = { region: region }
+            options[:credentials] = credentials if credentials
+            options
+          end
+
+          def credentials
+            @credentials ||= if @access_key_id && @secret_access_key
+              Aws::Credentials.new(@access_key_id, @secret_access_key)
+            end
+          end
+
+          def region
+            @region || "us-east-1"
+          end
+
+          def bucket
+            @s3_bucket ||= @bucket.respond_to?(:call) ? @bucket.call : @bucket
+          end
+
+          def folder
+            @s3_folder ||= @folder.respond_to?(:call) ? @folder.call : @folder
+          end
+
+          def url_for(path)
+            key = File.basename(path)
+            key = File.join(folder, key) if folder
+            "https://s3.amazonaws.com/#{bucket_name}/#{key}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/capybara-screenshot/spinach.rb
+++ b/lib/capybara-screenshot/spinach.rb
@@ -24,3 +24,7 @@ end
 Spinach.hooks.on_error_step do |*args|
   Capybara::Screenshot::Spinach.fail_with_screenshot(*args)
 end
+
+Spinach.hooks.after_run do |*args|
+  Capybara::Screenshot::S3.flush if Capybara::Screenshot.upload_to_s3?
+end

--- a/lib/capybara-screenshot/testunit.rb
+++ b/lib/capybara-screenshot/testunit.rb
@@ -30,6 +30,7 @@ Test::Unit::TestResult.class_eval do
           saver = Capybara::Screenshot::Saver.new(Capybara, Capybara.page, true, filename_prefix)
           saver.save
           saver.output_screenshot_path
+          Capybara::Screenshot::S3.flush if Capybara::Screenshot.upload_to_s3?
         end
       end
     end

--- a/spec/unit/capybara-screenshot_spec.rb
+++ b/spec/unit/capybara-screenshot_spec.rb
@@ -58,6 +58,36 @@ describe Capybara::Screenshot do
     end
   end
 
+  describe '.screenshot_and_save_page' do
+    let(:html_location) { 'page.html' }
+    let(:screenshot_location) { 'screenshot.png' }
+
+    it 'saves the image and page and returns their locations' do
+      allow_any_instance_of(Capybara::Screenshot::Saver).to receive(:save)
+      allow_any_instance_of(Capybara::Screenshot::Saver).to receive(:html_location).and_return(html_location)
+      allow_any_instance_of(Capybara::Screenshot::Saver).to receive(:screenshot_location).and_return(screenshot_location)
+
+      expect(Capybara::Screenshot.screenshot_and_save_page).to eq({
+        html: html_location, image: screenshot_location
+      })
+    end
+  end
+
+  describe '.screenshot_and_open_image' do
+    require "launchy"
+    let(:screenshot_location) { 'screenshot.png' }
+
+    it 'saves the image and page and returns their locations' do
+      allow(Launchy).to receive(:open)
+      allow_any_instance_of(Capybara::Screenshot::Saver).to receive(:save)
+      allow_any_instance_of(Capybara::Screenshot::Saver).to receive(:screenshot_location).and_return(screenshot_location)
+
+      expect(Capybara::Screenshot.screenshot_and_open_image).to eq({
+        html: nil, image: screenshot_location
+      })
+    end
+  end
+
   describe '#prune' do
     before do
       Capybara::Screenshot.reset_prune_history

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -121,22 +121,47 @@ describe Capybara::Screenshot::Saver do
 
   describe '#output_screenshot_path' do
     let(:saver) { Capybara::Screenshot::Saver.new(capybara_mock, page_mock) }
+    let(:html_path) { 'page.html' }
+    let(:screenshot_path) { 'screenshot.png' }
 
     before do
-      allow(saver).to receive(:html_path) { 'page.html' }
-      allow(saver).to receive(:screenshot_path) { 'screenshot.png' }
+      allow(saver).to receive(:html_path) { html_path }
+      allow(saver).to receive(:screenshot_path) { screenshot_path }
     end
 
     it 'outputs the path for the HTML screenshot' do
       allow(saver).to receive(:html_saved?).and_return(true)
-      expect(saver).to receive(:output).with("HTML screenshot: page.html")
+      expect(saver).to receive(:output).with("HTML screenshot: #{html_path}")
       saver.output_screenshot_path
     end
 
     it 'outputs the path for the Image screenshot' do
       allow(saver).to receive(:screenshot_saved?).and_return(true)
-      expect(saver).to receive(:output).with("Image screenshot: screenshot.png")
+      expect(saver).to receive(:output).with("Image screenshot: #{screenshot_path}")
       saver.output_screenshot_path
+    end
+
+    context 'when S3 uploads are enabled' do
+      let(:html_url) { 's3_page.html' }
+      let(:screenshot_url) { 's3_screenshot.png' }
+
+      before do
+        allow(saver).to receive(:upload_to_s3?) { true }
+        allow(Capybara::Screenshot::S3).to receive(:url_for).with(html_path).and_return(html_url)
+        allow(Capybara::Screenshot::S3).to receive(:url_for).with(screenshot_path).and_return(screenshot_url)
+      end
+
+      it 'outputs the url for the HTML screenshot' do
+        allow(saver).to receive(:html_saved?).and_return(true)
+        expect(saver).to receive(:output).with("HTML screenshot: #{html_url}")
+        saver.output_screenshot_path
+      end
+
+      it 'outputs the url for the Image screenshot' do
+        allow(saver).to receive(:screenshot_saved?).and_return(true)
+        expect(saver).to receive(:output).with("Image screenshot: #{screenshot_url}")
+        saver.output_screenshot_path
+      end
     end
   end
 


### PR DESCRIPTION
Ok, so this isn't ready to be merged yet, but I wanted to get eyes on it before I got too far along. I made the S3 integration opt-in as much as possible, but I couldn't find a clean way to avoid adding the `aws-sdk` to the Gemfile short of creating a separate gem.

A few things to note:
- For frameworks that support an 'after suite' hook (RSpec, MiniTest, Spinach), I am batching the uploads and processing them at the end of the run. For the others, I'm uploading them inline since I didn't see a clear way to do them on exit. I need to clean up the `enqueue/flush` strategy for these cases and can probably streamline it to just upload the files inline.
- Calling `screenshot_and_save_page` and `screenshot_and_open_image` doesn't upload the file to S3 by default, since I thought this would be the most common use case. It would seem that the S3 uploads are really only valuable in a CI context. Suggestions welcome on this.
- I didn't add the 'remove files from the filesystem' flag yet, but I think this could be easily done.

One question:
- Where are the `check_file_content` and `check_file_presence` spec helpers defined? I couldn't find them in the source, and adding the above 'remove files from the filesystem' option would break the specs that test for those files.

So yeah, please take a look at the changes and let me know what you think. It's working as-is with our RSpec-based suite, but likely quite a bit more testing would be required for the other frameworks. 

Cheers,

Mark
