### PR TITLE
Suggestion: Prepend file:// before screenshot file path in rspec text reporter

### DIFF
--- a/lib/capybara-screenshot/rspec/text_reporter.rb
+++ b/lib/capybara-screenshot/rspec/text_reporter.rb
@@ -26,8 +26,8 @@ module Capybara
         private
         def output_screenshot_info(example)
           return unless (screenshot = example.metadata[:screenshot])
-          output.puts(long_padding + CapybaraScreenshot::Helpers.yellow("HTML screenshot: #{screenshot[:html]}")) if screenshot[:html]
-          output.puts(long_padding + CapybaraScreenshot::Helpers.yellow("Image screenshot: #{screenshot[:image]}")) if screenshot[:image]
+          output.puts(long_padding + CapybaraScreenshot::Helpers.yellow("HTML screenshot: file://#{screenshot[:html]}")) if screenshot[:html]
+          output.puts(long_padding + CapybaraScreenshot::Helpers.yellow("Image screenshot: file://#{screenshot[:image]}")) if screenshot[:image]
         end
 
         def long_padding

--- a/spec/unit/rspec_reporters/text_reporter_spec.rb
+++ b/spec/unit/rspec_reporters/text_reporter_spec.rb
@@ -68,7 +68,7 @@ describe Capybara::Screenshot::RSpec::TextReporter do
 
     it 'appends the html file path to the original output' do
       @reporter.send(example_failed_method, example)
-      expect(@reporter.output.string).to eql("original failure info\n  #{CapybaraScreenshot::Helpers.yellow("HTML screenshot: path/to/html")}\n")
+      expect(@reporter.output.string).to eql("original failure info\n  #{CapybaraScreenshot::Helpers.yellow("HTML screenshot: file://path/to/html")}\n")
     end
   end
 
@@ -77,7 +77,7 @@ describe Capybara::Screenshot::RSpec::TextReporter do
 
     it 'appends the image path to the original output' do
       @reporter.send(example_failed_method, example)
-      expect(@reporter.output.string).to eql("original failure info\n  #{CapybaraScreenshot::Helpers.yellow("HTML screenshot: path/to/html")}\n  #{CapybaraScreenshot::Helpers.yellow("Image screenshot: path/to/image")}\n")
+      expect(@reporter.output.string).to eql("original failure info\n  #{CapybaraScreenshot::Helpers.yellow("HTML screenshot: file://path/to/html")}\n  #{CapybaraScreenshot::Helpers.yellow("Image screenshot: file://path/to/image")}\n")
     end
   end
 
@@ -93,6 +93,6 @@ describe Capybara::Screenshot::RSpec::TextReporter do
     old_reporter.singleton_class.send :include, described_class
     example = example_failed_method_argument_double(screenshot: { html: "path/to/html" })
     old_reporter.send(example_failed_method, example)
-    expect(old_reporter.output.string).to eql("original failure info\n  #{CapybaraScreenshot::Helpers.yellow("HTML screenshot: path/to/html")}\n")
+    expect(old_reporter.output.string).to eql("original failure info\n  #{CapybaraScreenshot::Helpers.yellow("HTML screenshot: file://path/to/html")}\n")
   end
 end


### PR DESCRIPTION
Motivation: Displaying paths to the screenshots prefixed with `file://` makes it easier to open screenshots directly form the terminal.