### PR TITLE
Ensure that save_and_open_page_path is re-set if save_page raises

### DIFF
--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -72,6 +72,7 @@ module Capybara
         old_path = Capybara.save_and_open_page_path
         Capybara.save_and_open_page_path = nil
         yield
+      ensure
         Capybara.save_and_open_page_path = old_path
       end
 

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -119,6 +119,20 @@ describe Capybara::Screenshot::Saver do
     expect(saver).to_not be_html_saved
   end
 
+  context 'when saving a screenshot fails' do
+    it 'still restores the original value of Capybara.save_and_open_page_path' do
+      Capybara.save_and_open_page_path = 'tmp/bananas'
+
+      expect(capybara_mock).to receive(:save_page).and_raise
+
+      expect {
+        saver.save
+      }.to raise_error
+
+      expect(Capybara.save_and_open_page_path).to eq('tmp/bananas')
+    end
+  end
+
   describe '#output_screenshot_path' do
     let(:saver) { Capybara::Screenshot::Saver.new(capybara_mock, page_mock) }
 


### PR DESCRIPTION
For the past couple of months, when the testrun in [my app](https://github.com/railsbridge/bridge_troll) fails particularly egregiously I would find that it left a bunch of screenshot HTML files in the project root instead of `tmp/capybara`, like so:

```
traviss-air:bridge_troll tjgrathwell$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   app/models/event.rb

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	screenshot_2015-05-03-15-52-33.521.html
	screenshot_2015-05-03-15-52-36.030.html
	screenshot_2015-05-03-15-52-36.351.html
```

I tracked down this problem today and found that if any individual test raises an error performing `capybara.save_page`, the `Capybara.save_and_open_page_path` remains set to nil, which causes files to start appearing in the project root.

There may be more stuff worth investigating here (like how to make `save_page` not crash under certain conditions) but this commit fixes the immediate problem.