### PR TITLE
Use older lambda syntax for 1.8.7 compatibility

### DIFF
--- a/lib/capybara-screenshot/pruner.rb
+++ b/lib/capybara-screenshot/pruner.rb
@@ -8,13 +8,13 @@ module Capybara
 
         @strategy_proc = case strategy
         when :keep_all
-          -> { }
+          lambda { }
         when :keep_last_run
-          -> { prune_with_last_run_strategy }
+          lambda { prune_with_last_run_strategy }
         when Hash
           raise ArgumentError, ":keep key is required" unless strategy[:keep]
           raise ArgumentError, ":keep value must be number greater than zero" unless strategy[:keep].to_i > 0
-          -> { prune_with_numeric_strategy(strategy[:keep].to_i) }
+          lambda { prune_with_numeric_strategy(strategy[:keep].to_i) }
         else
           fail "Invalid prune strategy #{strategy}. `:keep_all`or `{ keep: 10 }` are valid examples."
         end


### PR DESCRIPTION
In my company we are currently using 1.8.7 for a legacy app, which does not support the new lambda syntax.

Would you like to change this syntax to maximise compatibility?

Thank you for this great gem!
Carlos.