### PR TITLE
Don't output screenshot paths if they aren't saved

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -27,17 +27,19 @@ module Capybara
 
     def self.screenshot_and_save_page
       saver = Saver.new(Capybara, Capybara.page)
-      saver.save
-      {:html => saver.html_path, :image => saver.screenshot_path}
+      if saver.save
+        {:html => saver.html_path, :image => saver.screenshot_path}
+      end
     end
 
     def self.screenshot_and_open_image
       require "launchy"
 
       saver = Saver.new(Capybara, Capybara.page, false)
-      saver.save
-      Launchy.open saver.screenshot_path
-      {:html => nil, :image => saver.screenshot_path}
+      if saver.save
+        Launchy.open saver.screenshot_path
+        {:html => nil, :image => saver.screenshot_path}
+      end
     end
 
     class << self


### PR DESCRIPTION
Right now `Saver#save` returns `nil` and does nothing if the browser hasn't loaded any URL, but will still output paths to files that do not exist:

https://github.com/mattheworiordan/capybara-screenshot/blob/master/lib/capybara-screenshot/saver.rb#L22-L23

This at least stops tricking users into thinking screenshots are being taken when they aren't.