### PR TITLE
 fix using_session_with_screenshot rollback to previous session

### DIFF
--- a/lib/capybara-screenshot/capybara.rb
+++ b/lib/capybara-screenshot/capybara.rb
@@ -13,13 +13,11 @@ module Capybara
       Capybara::Screenshot.screenshot_and_open_image
     end
 
-    def using_session_with_screenshot(name)
-      using_session_without_screenshot(name) do
-        original_session_name = Capybara.session_name
-        Capybara::Screenshot.final_session_name = name
-        yield
-        Capybara::Screenshot.final_session_name = original_session_name
-      end
+    def using_session_with_screenshot(name,&blk)
+      original_session_name = Capybara.session_name
+      Capybara::Screenshot.final_session_name = name
+      using_session_without_screenshot(name,&blk)
+      Capybara::Screenshot.final_session_name = original_session_name
     end
 
     alias_method :using_session_without_screenshot, :using_session


### PR DESCRIPTION
`original_session name` must be fetched before the call to `using_session_without_screenshot` in order to be the real previous session name. Currently `original_session name` will have the same value as `name` thus the rolling back will not work correctly.

Rolling back is not done in an `ensure` block because failed test need to stay in the latest `final_session_name`