### PR TITLE
include minitest plugin for Minitest::Test class

### DIFF
--- a/lib/capybara-screenshot/minitest.rb
+++ b/lib/capybara-screenshot/minitest.rb
@@ -22,10 +22,15 @@ module Capybara::Screenshot::MiniTestPlugin
   end
 end
 
-class MiniTest::Unit::TestCase
-  include Capybara::Screenshot::MiniTestPlugin
+begin
+  Minitest.const_get('Test')
+  class Minitest::Test
+    include Capybara::Screenshot::MiniTestPlugin
+  end
+rescue NameError => e
+  class MiniTest::Unit::TestCase
+    include Capybara::Screenshot::MiniTestPlugin
+  end
 end
 
-class Minitest::Test
-  include Capybara::Screenshot::MiniTestPlugin
-end
+

--- a/lib/capybara-screenshot/minitest.rb
+++ b/lib/capybara-screenshot/minitest.rb
@@ -25,3 +25,7 @@ end
 class MiniTest::Unit::TestCase
   include Capybara::Screenshot::MiniTestPlugin
 end
+
+class Minitest::Test
+  include Capybara::Screenshot::MiniTestPlugin
+end


### PR DESCRIPTION
Minitest nowadays uses Minitest::Test instead of MiniTest::Unit::TestCase, which caused the plugin not to be loaded (and thus screenshots not to be printed). 