### PR TITLE
fixing capybara root when Rails is not defined

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -52,7 +52,7 @@ module Capybara
     end
 
     def self.capybara_root
-      @capybara_root ||= if defined?(::Rails)
+      @capybara_root ||= if defined?(::Rails) && Rails.root.present?
         ::Rails.root.join capybara_tmp_path
       elsif defined?(Padrino)
         Padrino.root capybara_tmp_path


### PR DESCRIPTION
This is to cater the specific scenario when, Rails gem is included in the project but not in a specific env.
And as in Rails Gemfile there is no provision to not include the gem in a specific group (we dont want to include in specific groups), we had to check for Rails.root.present?

Happy to explain further.

Cheers