### PR TITLE
Add information about MiniTestPlugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Typically in 'test/test_helper.rb', please add:
 require 'capybara-screenshot/minitest'
 ```
 
+Also, consider adding `include Capybara::Screenshot::MiniTestPlugin` to any test classes that fail. For example, to capture screenshots for all failing integration tests in minitest-rails, try something like:
+
+```ruby
+class ActionDispatch::IntegrationTest
+  include Capybara::Screenshot::MiniTestPlugin
+  # ...
+end
+```
+
 #### Test::Unit
 
 Typically in 'test/test_helper.rb', please add:


### PR DESCRIPTION
Before, there was no mention of the `MiniTestPlugin` in the readme (see confusion in #136).

At least for me, resetting the Capybara session between tests wasn't necessary; all it took was including the minitest plugin. 

@matt-riemer any thoughts/comments?