### PR TITLE
decouple minitest integration from ActionDispatch::IntegrationTest

### DIFF
--- a/lib/capybara-screenshot/minitest.rb
+++ b/lib/capybara-screenshot/minitest.rb
@@ -8,7 +8,7 @@ module Capybara::Screenshot::MiniTestPlugin
 
   def after_teardown
     super
-    if self.class.ancestors.map(&:to_s).include?('ActionDispatch::IntegrationTest')
+    if self.class.ancestors.map(&:to_s).include?('Capybara::DSL')
       if Capybara::Screenshot.autosave_on_failure && !passed? && !skipped?
         Capybara.using_session(Capybara::Screenshot.final_session_name) do
           filename_prefix = Capybara::Screenshot.filename_prefix_for(:minitest, self)

--- a/spec/feature/minitest_spec.rb
+++ b/spec/feature/minitest_spec.rb
@@ -32,11 +32,7 @@ describe "Using Capybara::Screenshot with MiniTest" do
 
   it 'saves a screenshot on failure' do
     run_failing_case <<-RUBY
-      module ActionDispatch
-        class IntegrationTest < Minitest::Unit::TestCase; end
-      end
-
-      class TestFailure < ActionDispatch::IntegrationTest
+      class TestFailure < MiniTest::Unit::TestCase
         include Capybara::DSL
 
         def test_failure
@@ -49,28 +45,9 @@ describe "Using Capybara::Screenshot with MiniTest" do
     expect('tmp/my_screenshot.html').to have_file_content('This is the root page')
   end
 
-  it "does not save a screenshot for tests that don't inherit from ActionDispatch::IntegrationTest" do
-    run_failing_case <<-RUBY
-      class TestFailure < MiniTest::Unit::TestCase
-        include Capybara::DSL
-
-        def test_failure
-          visit '/'
-          assert(page.body.include?('This is the root page'))
-          click_on "you'll never find me"
-        end
-      end
-    RUBY
-    expect('tmp/my_screenshot.html').to_not be_an_existing_file
-  end
-
   it 'saves a screenshot for the correct session for failures using_session' do
     run_failing_case <<-RUBY
-      module ActionDispatch
-        class IntegrationTest < Minitest::Unit::TestCase; end
-      end
-
-      class TestFailure < ActionDispatch::IntegrationTest
+      class TestFailure < Minitest::Unit::TestCase
         include Capybara::DSL
 
         def test_failure
@@ -91,11 +68,7 @@ describe "Using Capybara::Screenshot with MiniTest" do
     create_screenshot_for_pruning
     configure_prune_strategy :last_run
     run_failing_case <<-RUBY
-      module ActionDispatch
-        class IntegrationTest < Minitest::Unit::TestCase; end
-      end
-
-      class TestFailure < ActionDispatch::IntegrationTest
+      class TestFailure < Minitest::Unit::TestCase
         include Capybara::DSL
 
         def test_failure


### PR DESCRIPTION
this will allow this gem to work in cases where the test class does
not inherit from AD::IntegrationTest. it checks for Capybara::DSL in
the ancestor chain, instead, during teardown.

i, for one, have cases where the ancestor chain looks like this:

```
["redirect after login Feature Test",
 "Capybara::Rails::TestCase",
 "Minitest::Metadata",
 "Capybara::Assertions",
 "Capybara::DSL",
 "ActiveSupport::TestCase",
 "Warden::Test::Helpers",
 "Minitest::Rails::ConstantLookup",
 "Minitest::Spec::DSL::InstanceMethods",
 "ActiveSupport::Testing::TimeHelpers",
 "ActiveSupport::Testing::Deprecation",
 "ActiveSupport::Testing::Assertions",
 "ActiveSupport::Callbacks",
 "ActiveSupport::Testing::SetupAndTeardown",
 "ActiveSupport::Testing::TaggedLogging",
 "Minitest::Test",
 "WebMock::API",
 "Minitest::Guard",
 "Minitest::Test::LifecycleHooks",
 "Minitest::Assertions",
 "Minitest::Runnable",
 "Object",
 "Minitest::Rails::Expectations",
 "Minitest::Expectations",
 "ActiveSupport::Dependencies::Loadable",
 "PP::ObjectMixin",
 "JSON::Ext::Generator::GeneratorMethods::Object",
 "Kernel",
 "BasicObject"]
```