### PR TITLE
Add support for RSpec's JSON formatter

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -3,6 +3,7 @@ require "capybara-screenshot"
 require "capybara-screenshot/rspec/text_reporter"
 require "capybara-screenshot/rspec/html_link_reporter"
 require "capybara-screenshot/rspec/html_embed_reporter"
+require "capybara-screenshot/rspec/json_reporter"
 require "capybara-screenshot/rspec/textmate_link_reporter"
 
 module Capybara
@@ -39,6 +40,7 @@ module Capybara
         "RSpec::Core::Formatters::ProgressFormatter"      => Capybara::Screenshot::RSpec::TextReporter,
         "RSpec::Core::Formatters::DocumentationFormatter" => Capybara::Screenshot::RSpec::TextReporter,
         "RSpec::Core::Formatters::HtmlFormatter"          => Capybara::Screenshot::RSpec::HtmlLinkReporter,
+        "RSpec::Core::Formatters::JsonFormatter"          => Capybara::Screenshot::RSpec::JsonReporter,
         "RSpec::Core::Formatters::TextMateFormatter"      => Capybara::Screenshot::RSpec::TextMateLinkReporter, # RSpec 2
         "RSpec::Mate::Formatters::TextMateFormatter"      => Capybara::Screenshot::RSpec::TextMateLinkReporter,  # RSpec 3
         "Fuubar"                                          => Capybara::Screenshot::RSpec::TextReporter

--- a/lib/capybara-screenshot/rspec/json_reporter.rb
+++ b/lib/capybara-screenshot/rspec/json_reporter.rb
@@ -1,0 +1,19 @@
+require 'capybara-screenshot/rspec/base_reporter'
+
+module Capybara
+  module Screenshot
+    module RSpec
+      module JsonReporter
+        extend BaseReporter
+
+        enhance_with_screenshot :format_example
+
+        def format_example_with_screenshot(example)
+          format_example_without_screenshot(example).merge({
+            screenshot: example.metadata[:screenshot]
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/rspec_spec.rb
+++ b/spec/rspec/rspec_spec.rb
@@ -57,7 +57,8 @@ describe Capybara::Screenshot::RSpec, :type => :aruba do
     formatters = {
       progress:      'HTML screenshot:',
       documentation: 'HTML screenshot:',
-      html:          %r{<a href="file://\./tmp/screenshot\.html"[^>]*>HTML page</a>}
+      html:          %r{<a href="file://\./tmp/screenshot\.html"[^>]*>HTML page</a>},
+      json:          '"screenshot":{"'
     }
 
     # Textmate formatter is only included in RSpec 2


### PR DESCRIPTION
I created a small reporter to add screenshot information to RSpec's JSON output. 

When tests using this gem are run with `rspec --format json`, examples now have a `"screenshot"` member.

Passed example:
```
        {
            "description": "example test",
            "file_path": "./spec/example/example_spec.rb",
            "full_description": "an example test",
            "line_number": 4,
            "pending_message": null,
            "run_time": 0.1234567,
            "screenshot": null,          <-------- Added this
            "status": "passed"
        }
```

Failed example:
```
        {
            "description": "example failing test",
            "exception": {
                "backtrace": [
                    "snip: backtrace"
                ],
                "class": "Exception",
                "message": "Message Here"
            },
            "file_path": "./spec/example/example_spec.rb",
            "full_description": "failing example",
            "line_number": 6,
            "pending_message": null,
            "run_time": 0.56789,
            "screenshot": {                          <-------- Added this
                "html": "./path/to/screenshot.html",
                "image": "./path/to/screenshot.png"
            },
            "status": "failed"
        }
```

I'm happy to make changes as needed to get this merged.