### PR TITLE
Respect Capybara.save_path preference

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -94,7 +94,8 @@ module Capybara
 
     # If the path isn't set, default to the current directory
     def self.capybara_tmp_path
-      Capybara.save_and_open_page_path || '.'
+      # `#save_and_open_page_path` is now deprecated
+      Capybara.save_path || Capybara.save_and_open_page_path || '.'
     end
   end
 end


### PR DESCRIPTION
Newer versions of Capybara deprecated `#save_and_open_page_path` in favour of `#save_path`.

Deals with #164 