### PR TITLE
Fix undefined method `root' for Capybara::Rails:Module

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -54,7 +54,7 @@ module Capybara
     end
 
     def self.capybara_root
-      @capybara_root ||= if defined?(::Rails) && Rails.root.present?
+      @capybara_root ||= if defined?(::Rails) && ::Rails.root.present?
         ::Rails.root.join capybara_tmp_path
       elsif defined?(Padrino)
         File.expand_path(capybara_tmp_path, Padrino.root)


### PR DESCRIPTION
`Rails` without the `::` actually resolves to `Capybara::Rails`, which does not have the method `root`, this PR fixes the problem.