### PR TITLE
capybara_root should always use the namespace operator for Rails module lookup

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -54,7 +54,7 @@ module Capybara
     end
 
     def self.capybara_root
-      @capybara_root ||= if defined?(::Rails) && Rails.root.present?
+      @capybara_root ||= if defined?(::Rails) && ::Rails.root.present?
         ::Rails.root.join capybara_tmp_path
       elsif defined?(Padrino)
         File.expand_path(capybara_tmp_path, Padrino.root)


### PR DESCRIPTION
I noticed it using capybara-screenshot breaks while using minitest-rails-capybara because the base class is Capybara::Rails::TestCase which means that when `capybara_root` is called the non-namespaced `Rails.root` will lookup to Capybara::Rails and not Rails module.

Anyway, all the calls to the Rails module in that method should be namespaced :)