### PR TITLE
run MiniTestPlugin on #before_teardown

### DIFF
--- a/lib/capybara-screenshot/minitest.rb
+++ b/lib/capybara-screenshot/minitest.rb
@@ -6,7 +6,7 @@ module Capybara::Screenshot::MiniTestPlugin
     Capybara::Screenshot.final_session_name = nil
   end
 
-  def after_teardown
+  def before_teardown
     super
     if self.class.ancestors.map(&:to_s).include?('ActionDispatch::IntegrationTest')
       if Capybara::Screenshot.autosave_on_failure && !passed? && !skipped?


### PR DESCRIPTION
this makes the plugin compatible with other gems which may install
teardown callbacks and call `Capybara.reset_session!`like
minitest-capybara. see #136 for related discussion.

this may resolve #136?