### PR TITLE
fix test suite

### DIFF
--- a/spec/cucumber/cucumber_spec.rb
+++ b/spec/cucumber/cucumber_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 describe "Using Capybara::Screenshot with Cucumber" do
   include CommonSetup
 
-  before do
-    setup_aruba
-  end
-
   let(:cmd) { 'cucumber' }
 
   def run_failing_case(failure_message, code)

--- a/spec/feature/minitest_spec.rb
+++ b/spec/feature/minitest_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 describe "Using Capybara::Screenshot with MiniTest" do
   include CommonSetup
 
-  before do
-    setup_aruba
-  end
-
   def run_failing_case(code)
     write_file('test_failure.rb', <<-RUBY)
       #{ensure_load_paths_valid}

--- a/spec/feature/testunit_spec.rb
+++ b/spec/feature/testunit_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 describe "Using Capybara::Screenshot with Test::Unit" do
   include CommonSetup
 
-  before do
-    setup_aruba
-  end
-
   def run_failing_case(code, integration_path = '.')
     write_file("#{integration_path}/test_failure.rb", <<-RUBY)
       #{ensure_load_paths_valid}

--- a/spec/rspec/rspec_spec.rb
+++ b/spec/rspec/rspec_spec.rb
@@ -5,7 +5,6 @@ describe Capybara::Screenshot::RSpec, :type => :aruba do
     include CommonSetup
 
     before do
-      setup_aruba
       Capybara::Screenshot.capybara_tmp_path = expand_path('tmp')
     end
 

--- a/spec/spinach/spinach_spec.rb
+++ b/spec/spinach/spinach_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 describe "Using Capybara::Screenshot with Spinach" do
   include CommonSetup
 
-  before do
-    setup_aruba
-  end
-
   def run_failing_case(failure_message, code)
     write_file('steps/failure.rb', <<-RUBY)
       #{ensure_load_paths_valid}

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -1,3 +1,2 @@
 require 'aruba/rspec'
-require 'aruba/api'
 require 'aruba/config/jruby'


### PR DESCRIPTION
this aims to resolve #173.

as of now, it does the following:
- drop cucumber 1.2 support due to changes and dependencies of aruba 0.14
- drop rspec 2.14 support due to changes and dependencies of aruba 0.14
- drop spinach 0.7 support due to changes and dependencies of aruba 0.14
- supporting spinach from version 0.8.2
- lock mime-types gem to 2.99 for ruby < 2.0 compatibility
- add ruby 2.3 to test matrix

todo:
- rspec 2.99
