### PR TITLE
Update README for Capybara.save_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ By default, when running under Rails, Sinatra, and Padrino, screenshots are save
 If you want to customize the location, override the file path as:
 
 ```ruby
-Capybara.save_and_open_page_path = "/file/path"
+Capybara.save_path = "/file/path"
 ```
 
 


### PR DESCRIPTION
`Capybara.save_and_open_page_path` seems to be deprecated in favor of `Capybara.save_path`

I got this error in my test suite in Circle CI:

```
DEPRECATED: #save_and_open_page_path is deprecated, please use #save_path instead.
```

And indeed it didn't work with `#save_and_open_page_path` but it did work with `#save_path`.

If this is the new correct way to set the path, then this updates the README.