### PR TITLE
Add support for TeamCity's RSpec formatter.

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -43,7 +43,8 @@ module Capybara
         "RSpec::Core::Formatters::JsonFormatter"          => Capybara::Screenshot::RSpec::JsonReporter,
         "RSpec::Core::Formatters::TextMateFormatter"      => Capybara::Screenshot::RSpec::TextMateLinkReporter, # RSpec 2
         "RSpec::Mate::Formatters::TextMateFormatter"      => Capybara::Screenshot::RSpec::TextMateLinkReporter,  # RSpec 3
-        "Fuubar"                                          => Capybara::Screenshot::RSpec::TextReporter
+        "Fuubar"                                          => Capybara::Screenshot::RSpec::TextReporter,
+        "Spec::Runner::Formatter::TeamcityFormatter"      => Capybara::Screenshot::RSpec::TextReporter
       }
 
       class << self


### PR DESCRIPTION
This adds compatibility for not only TeamCity itself, but all JetBrains products (Rubymine, etc), which all use the TeamCity rspec formatter under the hood.
