### PR TITLE
Add direct screenshop option.

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -44,6 +44,13 @@ module Capybara
       end
     end
 
+    def self.screenshot(filename_prefix = nil)
+      saver = new_saver(Capybara, Capybara.page, false, filename_prefix)
+      if saver.save
+        {:html => nil, :image => saver.screenshot_path}
+      end
+    end
+
     class << self
       alias screen_shot_and_save_page screenshot_and_save_page
       alias screen_shot_and_open_image screenshot_and_open_image

--- a/lib/capybara-screenshot/capybara.rb
+++ b/lib/capybara-screenshot/capybara.rb
@@ -13,6 +13,10 @@ module Capybara
       Capybara::Screenshot.screenshot_and_open_image
     end
 
+    def screenshot(filename_prefix = nil)
+      Capybara::Screenshot.screenshot(filename_prefix)
+    end
+
     def using_session_with_screenshot(name,&blk)
       original_session_name = Capybara.session_name
       Capybara::Screenshot.final_session_name = name

--- a/spec/unit/capybara_spec.rb
+++ b/spec/unit/capybara_spec.rb
@@ -5,12 +5,14 @@ describe Capybara do
   it 'adds screen shot methods to the Capybara module' do
     expect(::Capybara).to respond_to(:screenshot_and_save_page)
     expect(::Capybara).to respond_to(:screenshot_and_open_image)
+    expect(::Capybara).to respond_to(:screenshot)
   end
 
   context 'request type example', :type => :request do
     it 'has access to screen shot instance methods' do
       expect(subject).to respond_to(:screenshot_and_save_page)
       expect(subject).to respond_to(:screenshot_and_open_image)
+      expect(subject).to respond_to(:screenshot)
     end
   end
 


### PR DESCRIPTION
This allows calling `screenshot 'some_file'` in a test to capture a screenshot, but without opening the file or saving the html.

I have added some tests, but I'm unsure on how to properly cover the rest of the suite. Please advise. Thanks.