### PR TITLE
in rspec, only test Capybara.page.current_url when there is an expectation exception

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -52,7 +52,7 @@ module Capybara
         def after_failed_example(example)
           if example.example_group.include?(Capybara::DSL) # Capybara DSL method has been included for a feature we can snapshot
             Capybara.using_session(Capybara::Screenshot.final_session_name) do
-              if Capybara.page.current_url != '' && Capybara::Screenshot.autosave_on_failure && example.exception
+              if Capybara::Screenshot.autosave_on_failure && example.exception && Capybara.page.current_url != ''
                 filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)
 
                 saver = Capybara::Screenshot.new_saver(Capybara, Capybara.page, true, filename_prefix)


### PR DESCRIPTION
  The previous logic meant every test (even ones that didn't use Capybara) caused Firefox to open after every test, even when there wasn't a test failure.

There's probably a better way to do this (Capybara::DSL ends up in all our rspec groups) based on whether it was an integration test or made use of Capybara, but this at least solves a chunk of the annoyance.