### PR TITLE
implement s3 object configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,15 @@ Capybara::Screenshot.s3_configuration = {
 }
 ```
 
+It is also possible to specify the object parameters such as acl.
+Configure the capybara-screenshot with these options in this way:
+
+```ruby
+Capybara::Screenshot.s3_object_configuration = {
+  acl: 'public-read'
+}
+```
+
 
 Pruning old screenshots automatically
 --------------------------

--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -10,6 +10,7 @@ module Capybara
       attr_writer   :final_session_name
       attr_accessor :prune_strategy
       attr_accessor :s3_configuration
+      attr_accessor :s3_object_configuration
     end
 
     self.autosave_on_failure = true
@@ -20,6 +21,7 @@ module Capybara
     self.webkit_options = {}
     self.prune_strategy = :keep_all
     self.s3_configuration = {}
+    self.s3_object_configuration = {}
 
     def self.append_screenshot_path=(value)
       $stderr.puts "WARNING: Capybara::Screenshot.append_screenshot_path is deprecated. " +
@@ -97,7 +99,7 @@ module Capybara
 
       unless s3_configuration.empty?
         require 'capybara-screenshot/s3_saver'
-        saver = S3Saver.new_with_configuration(saver, s3_configuration)
+        saver = S3Saver.new_with_configuration(saver, s3_configuration, s3_object_configuration)
       end
 
       return saver

--- a/lib/capybara-screenshot/s3_saver.rb
+++ b/lib/capybara-screenshot/s3_saver.rb
@@ -5,13 +5,14 @@ module Capybara
     class S3Saver
       DEFAULT_REGION = 'us-east-1'
 
-      def initialize(saver, s3_client, bucket_name)
+      def initialize(saver, s3_client, bucket_name, object_configuration)
         @saver = saver
         @s3_client = s3_client
         @bucket_name = bucket_name
+        @object_configuration = object_configuration
       end
 
-      def self.new_with_configuration(saver, configuration)
+      def self.new_with_configuration(saver, configuration, object_configuration)
         default_s3_client_credentials = {
           region: DEFAULT_REGION
         }
@@ -23,7 +24,7 @@ module Capybara
         s3_client = Aws::S3::Client.new(s3_client_credentials)
         bucket_name = configuration.fetch(:bucket_name)
 
-        new(saver, s3_client, bucket_name)
+        new(saver, s3_client, bucket_name, object_configuration)
       rescue KeyError
         raise "Invalid S3 Configuration #{configuration}. Please refer to the documentation for the necessary configurations."
       end
@@ -31,10 +32,16 @@ module Capybara
       def save_and_upload_screenshot
         save_and do |local_file_path|
           File.open(local_file_path) do |file|
+            object_payload = {
+              bucket: bucket_name,
+              key: File.basename(local_file_path),
+              body: file
+            }
+
+            object_payload.merge!(object_configuration) unless object_configuration.empty?
+
             s3_client.put_object(
-                bucket: bucket_name,
-                key: File.basename(local_file_path),
-                body: file
+                object_payload
             )
           end
         end
@@ -51,7 +58,8 @@ module Capybara
       private
       attr_reader :saver,
                   :s3_client,
-                  :bucket_name
+                  :bucket_name,
+                  :object_configuration
 
       def save_and
         saver.save

--- a/lib/capybara-screenshot/version.rb
+++ b/lib/capybara-screenshot/version.rb
@@ -1,5 +1,5 @@
 module Capybara
   module Screenshot
-    VERSION = '1.0.14'
+    VERSION = '1.0.15'
   end
 end

--- a/spec/unit/capybara-screenshot_spec.rb
+++ b/spec/unit/capybara-screenshot_spec.rb
@@ -81,11 +81,12 @@ describe Capybara::Screenshot do
       args = double('args')
       s3_saver_double = double('s3_saver')
       s3_configuration = { hello: 'world' }
+      s3_object_configuration = {}
 
       Capybara::Screenshot.s3_configuration = s3_configuration
 
       expect(Capybara::Screenshot::Saver).to receive(:new).with(args).and_return(saver_double)
-      expect(Capybara::Screenshot::S3Saver).to receive(:new_with_configuration).with(saver_double, s3_configuration).and_return(s3_saver_double)
+      expect(Capybara::Screenshot::S3Saver).to receive(:new_with_configuration).with(saver_double, s3_configuration, s3_object_configuration).and_return(s3_saver_double)
 
       expect(Capybara::Screenshot.new_saver(args)).to eq(s3_saver_double)
     end


### PR DESCRIPTION
I implemented the way to provide some optional parameters to s3 object saving process. This could be helpful when trying to provide the access to new object (as a main example).