### PR TITLE
Ensure the reporter module is not loaded multiple times.

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -88,6 +88,7 @@ RSpec.configure do |config|
     if Capybara::Screenshot::RSpec.add_link_to_screenshot_for_failed_examples
       RSpec.configuration.formatters.each do |formatter|
         next unless (reporter_module = Capybara::Screenshot::RSpec::REPORTERS[formatter.class.to_s])
+        next if formatter.singleton_class.included_modules.include?(reporter_module)
         formatter.singleton_class.send :include, reporter_module
       end
     end


### PR DESCRIPTION
Ensure the reporter module is not loaded multiple times when `before(:suite)` is run multiple times because of calling `RSpec::Core::Runner` more than once.

Related issue: https://github.com/buildkite/docs/pull/99

This PR fix problem with capybara-screenshot not working with gem [knapsack_pro](https://github.com/KnapsackPro/knapsack_pro-ruby)