### PR TITLE
Do not raise

### DIFF
--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -26,11 +26,14 @@ module Capybara
       end
 
       def save
+        begin
         # if current_path empty then nothing to screen shot as browser has not loaded any URL
-        return if page.current_path.to_s.empty?
-
-        save_html if @html_save
-        save_screenshot
+          if capybara.current_path.to_s.empty?
+            save_html if @html_save
+            save_screenshot
+          end
+        rescue StandardError
+        end
       end
 
       def save_html

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -26,14 +26,10 @@ module Capybara
       end
 
       def save
-        begin
-          # the current_path may raise error with selenium
-          if !page.current_path.to_s.empty?
-            save_html if @html_save
-            save_screenshot
-          end
-        rescue StandardError => e
-          p e
+        # the current_path may raise error with selenium
+        if !current_path.empty?
+          save_html if @html_save
+          save_screenshot
         end
       end
 
@@ -100,6 +96,15 @@ module Capybara
       end
 
       private
+
+      def current_path
+        begin
+          page.current_path.to_s
+        rescue StandardError => e
+          warn "WARN: Screenshot could not be saved. `page.current_path` raised exception: #{e}."
+          ''
+        end
+      end
 
       def output(message)
         puts "    #{CapybaraScreenshot::Helpers.yellow(message)}"

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -28,7 +28,7 @@ module Capybara
       def save
         begin
         # the current_path may raise error with selenium
-          if capybara.current_path.to_s.empty?
+          if !capybara.current_path.to_s.empty?
             save_html if @html_save
             save_screenshot
           end

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -40,7 +40,7 @@ module Capybara
               warn "WARN: Screenshot could not be saved. An exception is raised: #{e.inspect}."
             end
           else
-            warn 'WARN: Screenshot could not be saved. `page.current_path` is empty'
+            warn 'WARN: Screenshot could not be saved. `page.current_path` is empty.'
           end
         end
       end

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -27,7 +27,7 @@ module Capybara
 
       def save
         begin
-        # if current_path empty then nothing to screen shot as browser has not loaded any URL
+        # the current_path may raise error with selenium
           if capybara.current_path.to_s.empty?
             save_html if @html_save
             save_screenshot

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -27,12 +27,13 @@ module Capybara
 
       def save
         begin
-        # the current_path may raise error with selenium
-          if !capybara.current_path.to_s.empty?
+          # the current_path may raise error with selenium
+          if !page.current_path.to_s.empty?
             save_html if @html_save
             save_screenshot
           end
-        rescue StandardError
+        rescue StandardError => e
+          p e
         end
       end
 

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -28,8 +28,17 @@ module Capybara
       def save
         current_path do |path|
           if !path.empty?
-            save_html if @html_save
-            save_screenshot
+            begin
+              save_html if @html_save
+            rescue StandardError => e
+              warn "WARN: HTML source could not be saved. An exception is raised: #{e.inspect}."
+            end
+
+            begin
+              save_screenshot
+            rescue StandardError => e
+              warn "WARN: Screenshot could not be saved. An exception is raised: #{e.inspect}."
+            end
           else
             warn 'WARN: Screenshot could not be saved. `page.current_path` is empty'
           end
@@ -105,7 +114,7 @@ module Capybara
         begin
           path = page.current_path.to_s
         rescue StandardError => e
-          warn "WARN: Screenshot could not be saved. `page.current_path` raised exception: #{e}."
+          warn "WARN: Screenshot could not be saved. `page.current_path` raised exception: #{e.inspect}."
         end
         yield path if path
       end

--- a/lib/capybara-screenshot/saver.rb
+++ b/lib/capybara-screenshot/saver.rb
@@ -26,10 +26,13 @@ module Capybara
       end
 
       def save
-        # the current_path may raise error with selenium
-        if !current_path.empty?
-          save_html if @html_save
-          save_screenshot
+        current_path do |path|
+          if !path.empty?
+            save_html if @html_save
+            save_screenshot
+          else
+            warn 'WARN: Screenshot could not be saved. `page.current_path` is empty'
+          end
         end
       end
 
@@ -98,12 +101,13 @@ module Capybara
       private
 
       def current_path
+        # the current_path may raise error in selenium
         begin
-          page.current_path.to_s
+          path = page.current_path.to_s
         rescue StandardError => e
           warn "WARN: Screenshot could not be saved. `page.current_path` raised exception: #{e}."
-          ''
         end
+        yield path if path
       end
 
       def output(message)

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -122,19 +122,29 @@ describe Capybara::Screenshot::Saver do
     expect(saver).to_not be_html_saved
   end
 
-  context 'when saving a screenshot fails' do
-    it 'does not raise' do
-      expect(capybara_mock).to receive(:save_page).and_raise
+  context 'when save_page raises' do
+    it 'raises' do
+      allow(capybara_mock).to receive(:save_page).and_raise(NoMethodError)
 
       expect {
         saver.save
-      }.not_to raise_error(RuntimeError)
+      }.to raise_error(NoMethodError)
+    end
+  end
+
+  context 'when current_path raises' do
+    it 'does not raise' do
+      allow(page_mock).to receive(:current_path).and_raise
+
+      expect {
+        saver.save
+      }.not_to raise_error
     end
 
     it 'still restores the original value of Capybara.save_and_open_page_path' do
       Capybara::Screenshot.capybara_tmp_path = 'tmp/bananas'
 
-      expect(capybara_mock).to receive(:save_page).and_raise
+      allow(page_mock).to receive(:current_path).and_raise
 
       saver.save
 

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -112,14 +112,26 @@ describe Capybara::Screenshot::Saver do
     expect(saver).to_not be_html_saved
   end
 
-  it 'does not save if current_path is empty' do
-    allow(page_mock).to receive(:current_path).and_return(nil)
-    expect(capybara_mock).to_not receive(:save_page)
-    expect(driver_mock).to_not receive(:render)
+  context 'the current_path is empty' do
+    before(:each) do
+      allow(page_mock).to receive(:current_path).and_return(nil)
+    end
 
-    saver.save
-    expect(saver).to_not be_screenshot_saved
-    expect(saver).to_not be_html_saved
+    it 'does not save' do
+      expect(capybara_mock).to_not receive(:save_page)
+      expect(driver_mock).to_not receive(:render)
+
+      saver.save
+      expect(saver).to_not be_screenshot_saved
+      expect(saver).to_not be_html_saved
+    end
+
+    it 'prints a warning' do
+      expect(saver).to receive(:warn).with(
+        'WARN: Screenshot could not be saved. `page.current_path` is empty',
+      )
+      saver.save
+    end
   end
 
   context 'when save_page raises' do

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -123,14 +123,20 @@ describe Capybara::Screenshot::Saver do
   end
 
   context 'when saving a screenshot fails' do
+    it 'does not raise' do
+      expect(capybara_mock).to receive(:save_page).and_raise
+
+      expect {
+        saver.save
+      }.not_to raise_error(RuntimeError)
+    end
+
     it 'still restores the original value of Capybara.save_and_open_page_path' do
       Capybara::Screenshot.capybara_tmp_path = 'tmp/bananas'
 
       expect(capybara_mock).to receive(:save_page).and_raise
 
-      expect {
-        saver.save
-      }.to raise_error(RuntimeError)
+      saver.save
 
       if Capybara.respond_to?(:save_path)
         expect(Capybara.save_path).to eq('tmp/bananas')

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -134,24 +134,54 @@ describe Capybara::Screenshot::Saver do
     end
   end
 
-  context 'when save_page raises' do
-    it 'raises' do
-      allow(capybara_mock).to receive(:save_page).and_raise(NoMethodError)
+  context 'when save_html raises' do
+    before(:each) do
+      allow(saver).to receive(:save_html).and_raise(NoMethodError.new('some error'))
+    end
 
-      expect {
-        saver.save
-      }.to raise_error(NoMethodError)
+    it 'prints warning message' do
+      expect(saver).to receive(:warn).with(
+        'WARN: HTML source could not be saved. An exception is raised: #<NoMethodError: some error>.',
+      )
+      saver.save
+    end
+
+    it 'tries to save screenshot' do
+      expect(saver).to receive(:save_screenshot)
+      saver.save
+    end
+  end
+
+  context 'when save_screenshot raises' do
+    before(:each) do
+      allow(saver).to receive(:save_screenshot).and_raise(NoMethodError.new('some error'))
+    end
+
+    it 'prints warning message' do
+      expect(saver).to receive(:warn).with(
+        'WARN: Screenshot could not be saved. An exception is raised: #<NoMethodError: some error>.',
+      )
+      saver.save
+    end
+
+    it 'tries to save screenshot' do
+      expect(saver).to receive(:save_html)
+      saver.save
     end
   end
 
   context 'when current_path raises' do
-    it 'does not raise' do
-      allow(page_mock).to receive(:current_path).and_raise
-
-      expect {
-        saver.save
-      }.not_to raise_error
+    before(:each) do
+      allow(page_mock).to receive(:current_path).and_raise(NoMethodError.new('some error'))
     end
+
+    it 'prints warning message' do
+      expect(saver).to receive(:warn).with(
+        'WARN: Screenshot could not be saved. `page.current_path` raised exception: #<NoMethodError: some error>.',
+      )
+      saver.save
+    end
+
 
     it 'still restores the original value of Capybara.save_and_open_page_path' do
       Capybara::Screenshot.capybara_tmp_path = 'tmp/bananas'

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -128,7 +128,7 @@ describe Capybara::Screenshot::Saver do
 
     it 'prints a warning' do
       expect(saver).to receive(:warn).with(
-        'WARN: Screenshot could not be saved. `page.current_path` is empty',
+        'WARN: Screenshot could not be saved. `page.current_path` is empty.',
       )
       saver.save
     end
@@ -182,6 +182,10 @@ describe Capybara::Screenshot::Saver do
       saver.save
     end
 
+    it 'does not print extra warning message' do
+      expect(saver).not_to receive(:warn).with(/is empty/)
+      saver.save
+    end
 
     it 'still restores the original value of Capybara.save_and_open_page_path' do
       Capybara::Screenshot.capybara_tmp_path = 'tmp/bananas'


### PR DESCRIPTION
### Motivation

See the screenshot:
![screen shot 2017-06-26 at 1 47 36 pm](https://user-images.githubusercontent.com/22895/27567744-a61cf7e6-5aa2-11e7-836e-e3c84106973f.png)

When calling `page.current_path` it raises a `UnhandledAlertError`. There is nowhere the spinach handles the exceptions so the hooks broke and no report is written into XML file (when using jUnit report formatter). That means the result report will say no failures. It makes debug very hard

![screen shot 2017-06-26 at 7 15 27 pm](https://user-images.githubusercontent.com/22895/27567952-ea4e80a0-5aa3-11e7-802f-ac6af7fe182b.png)


I went back and forth to think should I handle from spinach or from this gem. I could handle it from spinach, however spinach has no context on how to handle the exceptions. In this gem there is not a very good way to take screenshots when `current_path` raises so I can accept in this situation no screenshot is taken.

Please let me know your thoughts, thanks you