### PR TITLE
Requires only S3 Service of AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ Uploading screenshots to S3
 --------------------------
 You can configure capybara-screenshot to automatically save your screenshots to an AWS S3 bucket.
 
-First, install the `aws-sdk` gem or add it to your Gemfile
+First, install the `aws-sdk-s3` gem or add it to your Gemfile
 
 ```ruby
-gem 'capybara-screenshot', :group => :test
-gem 'aws-sdk', :group => :test
+gem 'aws-sdk-s3', group: :test
+gem 'capybara-screenshot', group: :test
 ```
 
 Next, configure capybara-screenshot with your S3 credentials, the bucket to save to, and an optional region (default: `us-east-1`).

--- a/capybara-screenshot.gemspec
+++ b/capybara-screenshot.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'spinach'
   s.add_development_dependency 'minitest'
-  s.add_development_dependency 'aws-sdk'
+  s.add_development_dependency 'aws-sdk-s3'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/capybara-screenshot/s3_saver.rb
+++ b/lib/capybara-screenshot/s3_saver.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 module Capybara
   module Screenshot


### PR DESCRIPTION
AWS SDK v3 now has separated service gems.
This will reduce the dependencies.

https://github.com/aws/aws-sdk-ruby/blob/master/V3_UPGRADING_GUIDE.md