### PR TITLE
Add support for selenium_chrome and selenium_chrome_headless

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -156,9 +156,13 @@ Capybara::Screenshot.class_eval do
     :not_supported
   end
 
-  register_driver(:selenium) do |driver, path|
+  selenium_block = proc do |driver, path|
     driver.browser.save_screenshot(path)
   end
+
+  register_driver :selenium, &selenium_block
+  register_driver :selenium_chrome, &selenium_block
+  register_driver :selenium_chrome_headless, &selenium_block
 
   register_driver(:poltergeist) do |driver, path|
     driver.render(path, :full => true)


### PR DESCRIPTION
As of [capybara 2.15.0](https://github.com/teamcapybara/capybara/blob/master/History.md#version-2150) there are built-in drivers for [`:selenium_chrome` and `:selenium_chrome_headless`](https://github.com/teamcapybara/capybara/blob/bf8d6e8c320db6f809301937fece58394c7e1349/lib/capybara.rb#L485-L494)