### PR TITLE
Fix aggregate_failure tests

### DIFF
--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -53,7 +53,7 @@ module Capybara
         def after_failed_example(example)
           if example.example_group.include?(Capybara::DSL) # Capybara DSL method has been included for a feature we can snapshot
             Capybara.using_session(Capybara::Screenshot.final_session_name) do
-              if Capybara::Screenshot.autosave_on_failure && example.exception && Capybara.page.current_url != ''
+              if Capybara::Screenshot.autosave_on_failure && should_screenshot?(example) && Capybara.page.current_url != ''
                 filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)
 
                 saver = Capybara::Screenshot.new_saver(Capybara, Capybara.page, true, filename_prefix)
@@ -65,6 +65,10 @@ module Capybara
               end
             end
           end
+        end
+
+        def should_screenshot?(example)
+          example.exception || (example.metadata[:aggregate_failures] && ::RSpec::Support.failure_notifier.failures.any?)
         end
       end
 

--- a/lib/capybara-screenshot/rspec.rb
+++ b/lib/capybara-screenshot/rspec.rb
@@ -53,7 +53,7 @@ module Capybara
         def after_failed_example(example)
           if example.example_group.include?(Capybara::DSL) # Capybara DSL method has been included for a feature we can snapshot
             Capybara.using_session(Capybara::Screenshot.final_session_name) do
-              if Capybara::Screenshot.autosave_on_failure && should_screenshot?(example) && Capybara.page.current_url != ''
+              if Capybara::Screenshot.autosave_on_failure && failed_example?(example) && Capybara.page.current_url != ''
                 filename_prefix = Capybara::Screenshot.filename_prefix_for(:rspec, example)
 
                 saver = Capybara::Screenshot.new_saver(Capybara, Capybara.page, true, filename_prefix)
@@ -67,7 +67,7 @@ module Capybara
           end
         end
 
-        def should_screenshot?(example)
+        def failed_example?(example)
           example.exception || (example.metadata[:aggregate_failures] && ::RSpec::Support.failure_notifier.failures.any?)
         end
       end

--- a/spec/rspec/rspec_spec.rb
+++ b/spec/rspec/rspec_spec.rb
@@ -53,6 +53,19 @@ describe Capybara::Screenshot::RSpec, :type => :aruba do
       expect(expand_path('tmp/screenshot.html')).to_not have_file_content('This is the root page')
     end
 
+    it 'saves a screenshot on failure for aggregate_failure tests' do
+      run_failing_case <<-RUBY, %q{Unable to find link or button "you'll never find me"}
+        feature 'screenshot with failure' do
+          scenario 'click on a missing link', aggregate_failures: true do
+            visit '/'
+            expect(page.body).to include('This is the root page')
+            click_on "you'll never find me"
+          end
+        end
+      RUBY
+      expect(expand_path('tmp/screenshot.html')).to_not have_file_content('This is the root page')
+    end
+
     formatters = {
       progress:      'HTML screenshot:',
       documentation: 'HTML screenshot:',


### PR DESCRIPTION
RSpec's `aggregate_failures: true` does not result in an exception being set on an example. After digging into RSpec's code, it uses a failure notifier to determine if the test has failed. If the example has metadata indicating it's aggregating failures, this checks the failure notifier to determine if it should screenshot.

None of the rspec specs pass locally for me (on this or on master), but I believe they should work fine.