### PR TITLE
Fix ruby version compares

### DIFF
--- a/capybara-screenshot.gemspec
+++ b/capybara-screenshot.gemspec
@@ -15,11 +15,14 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "capybara-screenshot"
 
-  if RUBY_VERSION < "1.9"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9")
     s.add_dependency 'capybara', ['>= 1.0', '< 2']
+  elsif Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.2.2")
+    s.add_dependency 'capybara', ['>= 1.0', '< 3']
   else
     s.add_dependency 'capybara', ['>= 1.0', '< 4']
   end
+
   s.add_dependency 'launchy'
 
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
String instance of "2.2.2" is bigger than "2.2.10", so I use Gem::Version to compare semvers

related https://github.com/mattheworiordan/capybara-screenshot/pull/229