### PR TITLE
Feature/fix warnings

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -106,11 +106,11 @@ module Capybara
     end
 
     def self.after_save_html &block
-      Saver.after_save_html( &block )
+      Saver.after_save_html(&block)
     end
 
     def self.after_save_screenshot &block
-      Saver.after_save_screenshot( &block )
+      Saver.after_save_screenshot(&block)
     end
 
     private

--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -106,11 +106,11 @@ module Capybara
     end
 
     def self.after_save_html &block
-      Saver.after_save_html &block
+      Saver.after_save_html( &block )
     end
 
     def self.after_save_screenshot &block
-      Saver.after_save_screenshot &block
+      Saver.after_save_screenshot( &block )
     end
 
     private

--- a/lib/capybara-screenshot/callbacks.rb
+++ b/lib/capybara-screenshot/callbacks.rb
@@ -4,7 +4,7 @@ module Capybara
       class CallbackSet < Array
         def call *args
           each do |callback|
-            callback.call( *args )
+            callback.call(*args)
           end
         end
       end
@@ -24,7 +24,7 @@ module Capybara
 
         def run_callbacks name, *args
           if cb_set = callbacks[name]
-            cb_set.call( *args )
+            cb_set.call(*args)
           end
         end
       end

--- a/lib/capybara-screenshot/callbacks.rb
+++ b/lib/capybara-screenshot/callbacks.rb
@@ -4,7 +4,7 @@ module Capybara
       class CallbackSet < Array
         def call *args
           each do |callback|
-            callback.call *args
+            callback.call( *args )
           end
         end
       end
@@ -24,7 +24,7 @@ module Capybara
 
         def run_callbacks name, *args
           if cb_set = callbacks[name]
-            cb_set.call *args
+            cb_set.call( *args )
           end
         end
       end

--- a/lib/capybara-screenshot/minitest.rb
+++ b/lib/capybara-screenshot/minitest.rb
@@ -27,7 +27,7 @@ begin
   class Minitest::Test
     include Capybara::Screenshot::MiniTestPlugin
   end
-rescue NameError => e
+rescue NameError
   class MiniTest::Unit::TestCase
     include Capybara::Screenshot::MiniTestPlugin
   end

--- a/lib/capybara-screenshot/pruner.rb
+++ b/lib/capybara-screenshot/pruner.rb
@@ -26,7 +26,10 @@ module Capybara
       end
 
       private
-      attr_reader :strategy_proc
+      
+      def strategy_proc
+        @strategy_proc
+      end
 
       def wildcard_path
         File.expand_path('*.{html,png}', Screenshot.capybara_root)


### PR DESCRIPTION
fix multiple warnings when running under new rubies


* fix assigned but unused warning in NameError rescue in minitest.rb
* fix “`&' interpreted as argument prefix” warnings in capybara-screens… …
* fix “warning: `*' interpreted as argument prefix” in callbacks.rb
* fix “private attribute?” warning in pruner.rb