### PR TITLE
fix circular reference warning in capybara.rb

### DIFF
--- a/lib/capybara-screenshot/capybara.rb
+++ b/lib/capybara-screenshot/capybara.rb
@@ -1,5 +1,3 @@
-require "capybara-screenshot"
-
 module Capybara
   module DSL
     # Adds class methods to Capybara module and gets mixed into


### PR DESCRIPTION
This one is a little more contentious, so done in a separate PR