### PR TITLE
Fix specs to work with Capybara 3+

### DIFF
--- a/spec/cucumber/cucumber_spec.rb
+++ b/spec/cucumber/cucumber_spec.rb
@@ -32,7 +32,7 @@ describe "Using Capybara::Screenshot with Cucumber" do
   end
 
   it 'saves a screenshot on failure' do
-    run_failing_case %q{Unable to find visible link or button "you'll never find me"}, <<-CUCUMBER
+    run_failing_case %q{Unable to find (visible )?link or button "you'll never find me"}, <<-CUCUMBER
       Feature: Failure
         Scenario: Failure
           Given I visit "/"
@@ -52,7 +52,7 @@ describe "Using Capybara::Screenshot with Cucumber" do
   end
 
   it 'saves a screenshot for the correct session for failures using_session' do
-    run_failing_case(%q{Unable to find visible link or button "you'll never find me"}, <<-CUCUMBER)
+    run_failing_case(%q{Unable to find (visible )?link or button "you'll never find me"}, <<-CUCUMBER)
       Feature: Failure
         Scenario: Failure in different session
           Given I visit "/"
@@ -68,7 +68,7 @@ describe "Using Capybara::Screenshot with Cucumber" do
     end
 
     it 'on failure it prunes previous screenshots when strategy is set' do
-      run_failing_case %q{Unable to find visible link or button "you'll never find me"}, <<-CUCUMBER
+      run_failing_case %q{Unable to find (visible )?link or button "you'll never find me"}, <<-CUCUMBER
         Feature: Prune
           Scenario: Screenshots are pruned if strategy is set
             Given I visit "/"

--- a/spec/feature/minitest_spec.rb
+++ b/spec/feature/minitest_spec.rb
@@ -23,7 +23,7 @@ describe "Using Capybara::Screenshot with MiniTest" do
 
     cmd = 'bundle exec ruby test_failure.rb'
     run_simple_with_retry cmd, false
-    expect(last_command_started.output).to include %q{Unable to find visible link or button "you'll never find me"}
+    expect(last_command_started.output).to match %r{Unable to find (visible )?link or button "you'll never find me"}
   end
 
   it 'saves a screenshot on failure' do

--- a/spec/feature/testunit_spec.rb
+++ b/spec/feature/testunit_spec.rb
@@ -14,7 +14,7 @@ describe "Using Capybara::Screenshot with Test::Unit" do
 
       #{setup_test_app}
       Capybara::Screenshot.register_filename_prefix_formatter(:testunit) do | fault |
-        raise "expected fault" unless fault.exception.message.include? %q{Unable to find visible link or button "you'll never find me"}
+        raise "expected fault" unless fault.exception.message.match %r{Unable to find (visible )?link or button "you'll never find me"}
         'my_screenshot'
       end
 
@@ -29,7 +29,7 @@ describe "Using Capybara::Screenshot with Test::Unit" do
 
     cmd = "bundle exec ruby #{integration_path}/test_failure.rb"
     run_simple_with_retry cmd, false
-    expect(last_command_started.output).to include %q{Unable to find visible link or button "you'll never find me"}
+    expect(last_command_started.output).to match %r{Unable to find (visible )?link or button "you'll never find me"}
   end
 
   it "saves a screenshot on failure for any test in path 'test/integration'" do

--- a/spec/rspec/rspec_spec.rb
+++ b/spec/rspec/rspec_spec.rb
@@ -41,7 +41,7 @@ describe Capybara::Screenshot::RSpec, :type => :aruba do
     end
 
     it 'saves a screenshot when browser action fails' do
-      run_failing_case <<-RUBY, %q{Unable to find visible link or button "you'll never find me"}
+      run_failing_case <<-RUBY, %r{Unable to find (visible )?link or button "you'll never find me"}
         feature 'screenshot with failure' do
           scenario 'click on a missing link' do
             visit '/'
@@ -103,7 +103,7 @@ describe Capybara::Screenshot::RSpec, :type => :aruba do
     end
 
     it 'saves a screenshot for the correct session for failures using_session' do
-      run_failing_case <<-RUBY, %q{Unable to find visible link or button "you'll never find me"}
+      run_failing_case <<-RUBY, %r{Unable to find (visible )?link or button "you'll never find me"}
         feature 'screenshot with failure' do
           scenario 'click on a missing link' do
             visit '/'

--- a/spec/spinach/spinach_spec.rb
+++ b/spec/spinach/spinach_spec.rb
@@ -17,7 +17,7 @@ describe "Using Capybara::Screenshot with Spinach" do
   end
 
   it "saves a screenshot on failure" do
-    run_failing_case(%q{Unable to find visible link or button "you'll never find me"}, <<-GHERKIN)
+    run_failing_case(%q{Unable to find (visible )?link or button "you'll never find me"}, <<-GHERKIN)
       Feature: Failure
         Scenario: Failure
           Given I visit "/"
@@ -37,7 +37,7 @@ describe "Using Capybara::Screenshot with Spinach" do
   end
 
   it "saves a screenshot for the correct session for failures using_session" do
-    run_failing_case(%q{Unable to find visible link or button "you'll never find me"}, <<-GHERKIN)
+    run_failing_case(%q{Unable to find (visible )?link or button "you'll never find me"}, <<-GHERKIN)
       Feature: Failure
         Scenario: Failure in different session
           Given I visit "/"
@@ -49,7 +49,7 @@ describe "Using Capybara::Screenshot with Spinach" do
   it 'on failure it prunes previous screenshots when strategy is set' do
     create_screenshot_for_pruning
     configure_prune_strategy :last_run
-    run_failing_case(%q{Unable to find visible link or button "you'll never find me"}, <<-GHERKIN)
+    run_failing_case(%q{Unable to find (visible )?link or button "you'll never find me"}, <<-GHERKIN)
       Feature: Failure
         Scenario: Failure
           Given I visit "/"


### PR DESCRIPTION
In Capybara 3 the error message was changed from „Unable to find visible link or button …” to “Unable to find link or button …”.

This commit is a backward-compatible fix, so that the specs now work with both Capybara 2 and Capybara 3.