### PR TITLE
Fix .capybara_root with partial Rails environment loaded

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -58,7 +58,7 @@ module Capybara
     end
 
     def self.capybara_root
-      @capybara_root ||= if defined?(::Rails) && ::Rails.root.present?
+      @capybara_root ||= if defined?(::Rails) && ::Rails.respond_to?(:root) && ::Rails.root.present?
         ::Rails.root.join capybara_tmp_path
       elsif defined?(Padrino)
         File.expand_path(capybara_tmp_path, Padrino.root)


### PR DESCRIPTION
In our tests we are not loading the entire Rails environment to speed up our suite, but we do require a number of ActiveSupport/ActionView helpers. This breaks `capybara-screenshot` as the Rails module is loaded, but `::Rails.root` raises `NoMethodError`.

This is a minor fix to ensure that the `::Rails.root` function is callable.