### PR TITLE
Fix path output for s3-saved screenshots

### DIFF
--- a/lib/capybara-screenshot/s3_saver.rb
+++ b/lib/capybara-screenshot/s3_saver.rb
@@ -51,7 +51,7 @@ module Capybara
 
             s3_region = s3_client.get_bucket_location(bucket: bucket_name).location_constraint
 
-            send("#{type}_path=", "https://#{bucket_name}.s3-#{s3_region}.amazonaws.com/#{s3_upload_path}")
+            send("#{type}_path=", "https://#{bucket_name}.s3.amazonaws.com/#{s3_upload_path}")
           end
         end
       end


### PR DESCRIPTION
AWS has changed their URL structure such that the prior output for
screenshot location no longer works. The following change updates the
format to remove the invalid dash and the region name from the bucket
hostname.