### PR TITLE
Allow to set bucket location to avoid get_bucket_location request

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,15 @@ Capybara::Screenshot.s3_configuration = {
     secret_access_key: "my_secret_access_key",
     region: "eu-central-1"
   },
-  bucket_name: "my_screenshots"
+  bucket_name: "my_screenshots",
+  # Optionally: Specify the bucket location to save a request
+  bucket_location: "eu-central-1"
 }
 ```
+
+The access key used for S3 uploads need to have at least the `s3:PutObject` permission.
+
+**Note**: If you do not provide the `bucket_location` configuration option, additionally the `s3:GetBucketLocation` permission is required on the bucket for uploads to succeed.
 
 It is also possible to specify the object parameters such as acl.
 Configure the capybara-screenshot with these options in this way:

--- a/lib/capybara-screenshot/s3_saver.rb
+++ b/lib/capybara-screenshot/s3_saver.rb
@@ -11,6 +11,7 @@ module Capybara
         @saver = saver
         @s3_client = s3_client
         @bucket_name = bucket_name
+        @bucket_location = options[:bucket_location]
         @key_prefix = options[:key_prefix]
         @object_configuration = object_configuration
       end
@@ -49,7 +50,7 @@ module Capybara
                 object_payload
             )
 
-            s3_region = s3_client.get_bucket_location(bucket: bucket_name).location_constraint
+            s3_region = bucket_location || determine_bucket_location
 
             send("#{type}_path=", "https://#{bucket_name}.s3-#{s3_region}.amazonaws.com/#{s3_upload_path}")
           end
@@ -68,8 +69,16 @@ module Capybara
       attr_reader :saver,
                   :s3_client,
                   :bucket_name,
+                  :bucket_location,
                   :object_configuration
                   :key_prefix
+
+      ##
+      # Reads the bucket location using a S3 get_bucket_location request.
+      # Requires the +s3:GetBucketLocation+ policy.
+      def determine_bucket_location
+        s3_client.get_bucket_location(bucket: bucket_name).location_constraint
+      end
 
       def save_and
         saver.save

--- a/spec/unit/s3_saver_spec.rb
+++ b/spec/unit/s3_saver_spec.rb
@@ -5,10 +5,11 @@ describe Capybara::Screenshot::S3Saver do
   let(:saver) { double('saver') }
   let(:bucket_name) { double('bucket_name') }
   let(:s3_object_configuration) { {} }
+  let(:options) { {} }
   let(:s3_client) { double('s3_client') }
   let(:key_prefix){ "some/path/" }
 
-  let(:s3_saver) { described_class.new(saver, s3_client, bucket_name, s3_object_configuration) }
+  let(:s3_saver) { described_class.new(saver, s3_client, bucket_name, s3_object_configuration, options) }
   let(:s3_saver_with_key_prefix) { described_class.new(saver, s3_client, bucket_name, s3_object_configuration, key_prefix: key_prefix) }
 
   let(:region) { double('region') }
@@ -104,6 +105,20 @@ describe Capybara::Screenshot::S3Saver do
       allow(saver).to receive(:save)
     end
 
+    context 'providing a bucket_location' do
+      let(:options) { { bucket_location: 'some other location' } }
+  
+      it 'does not request the bucket location' do
+        screenshot_path = '/baz/bim.jpg'
+  
+        screenshot_file = double('screenshot_file')
+  
+        expect(s3_saver).not_to receive(:determine_bucket_location)
+  
+        s3_saver.save
+      end
+    end
+
     it 'calls save on the underlying saver' do
       expect(saver).to receive(:save)
 
@@ -124,6 +139,8 @@ describe Capybara::Screenshot::S3Saver do
         key: 'bar.html',
         body: html_file
       )
+
+      expect(s3_saver).to receive(:determine_bucket_location).and_call_original
 
       s3_saver.save
     end


### PR DESCRIPTION
As noted in https://github.com/mattheworiordan/capybara-screenshot/pull/239#issuecomment-449782254, it is currently required to fetch the bucket location to form the S3
URL which now requires the bucket name to be present.

By optionally accepting a `bucket_location` parameter in the s3 configuration, we can save this request and also avoid having to provide the `s3:GetBucketLocation` permission on the bucket.

The README is extended to reflect this change.

We have stumbled upon this discussion because after upgrading to the latest version, our screenshot uploading was broken due to the missing `s3:GetBucketLocation` permission.