### PR TITLE
Fix deprecation warnings for Aruba#run_simple

### DIFF
--- a/spec/cucumber/cucumber_spec.rb
+++ b/spec/cucumber/cucumber_spec.rb
@@ -26,7 +26,7 @@ describe "Using Capybara::Screenshot with Cucumber" do
 
     write_file('features/cucumber.feature', code)
 
-    run_simple_with_retry cmd, false
+    run_simple_with_retry cmd
 
     expect(last_command_started.output).to_not match(/failed|failure/i) if options[:assert_all_passed]
   end

--- a/spec/feature/minitest_spec.rb
+++ b/spec/feature/minitest_spec.rb
@@ -22,7 +22,7 @@ describe "Using Capybara::Screenshot with MiniTest" do
     RUBY
 
     cmd = 'bundle exec ruby test_failure.rb'
-    run_simple_with_retry cmd, false
+    run_simple_with_retry cmd
     expect(last_command_started.output).to match %r{Unable to find (visible )?link or button "you'll never find me"}
   end
 

--- a/spec/feature/testunit_spec.rb
+++ b/spec/feature/testunit_spec.rb
@@ -28,7 +28,7 @@ describe "Using Capybara::Screenshot with Test::Unit" do
     RUBY
 
     cmd = "bundle exec ruby #{integration_path}/test_failure.rb"
-    run_simple_with_retry cmd, false
+    run_simple_with_retry cmd
     expect(last_command_started.output).to match %r{Unable to find (visible )?link or button "you'll never find me"}
   end
 

--- a/spec/rspec/rspec_spec.rb
+++ b/spec/rspec/rspec_spec.rb
@@ -31,7 +31,7 @@ describe Capybara::Screenshot::RSpec, :type => :aruba do
       RUBY
 
       cmd = cmd_with_format(options[:format])
-      run_simple_with_retry cmd, false
+      run_simple_with_retry cmd
 
       expect(last_command_started.output).to match('0 failures') if options[:assert_all_passed]
     end

--- a/spec/spinach/spinach_spec.rb
+++ b/spec/spinach/spinach_spec.rb
@@ -12,7 +12,7 @@ describe "Using Capybara::Screenshot with Spinach" do
 
     write_file('spinach.feature', code)
     cmd = 'bundle exec spinach -f .'
-    run_simple_with_retry cmd, false
+    run_simple_with_retry cmd
     expect(last_command_started.output).to match(failure_message)
   end
 

--- a/spec/support/common_setup.rb
+++ b/spec/support/common_setup.rb
@@ -41,11 +41,11 @@ module CommonSetup
       end
     end
 
-    def run_simple_with_retry(*args)
-      run_simple(*args)
+    def run_simple_with_retry(cmd, fail_on_error: false)
+      run_command_and_stop(cmd, fail_on_error: fail_on_error)
     rescue ChildProcess::TimeoutError => e
-      puts "run_simple(#{args.join(', ')}) failed. Will retry once. `#{e.message}`"
-      run_simple(*args)
+      puts "run_command_and_stop(#{cmd}, fail_on_error: #{fail_on_error}) failed. Will retry once. `#{e.message}`"
+      run_command_and_stop(cmd, fail_on_error: fail_on_error)
     end
 
     def configure_prune_strategy(strategy)


### PR DESCRIPTION
- Replace #run_simple with run_command_and_stop
- Update #run_simple_with_retry