### PR TITLE
Add bucket_host option to fully specify S3 host

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ Capybara::Screenshot.s3_configuration = {
     region: "eu-central-1"
   },
   bucket_name: "my_screenshots",
-  # Optionally: Specify the bucket location to save a request
-  bucket_location: "eu-central-1"
+  # Optionally: Specify the host used to access the uploaded screenshots
+  bucket_host: "my_screenshots.s3-eu-central-1.amazonaws.com",
 }
 ```
 
 The access key used for S3 uploads need to have at least the `s3:PutObject` permission.
 
-**Note**: If you do not provide the `bucket_location` configuration option, additionally the `s3:GetBucketLocation` permission is required on the bucket for uploads to succeed.
+**Note**: If you do not provide the `bucket_host` configuration option, additionally the `s3:GetBucketLocation` permission is required on the bucket for uploads to succeed.
 
 It is also possible to specify the object parameters such as acl.
 Configure the capybara-screenshot with these options in this way:

--- a/README.md
+++ b/README.md
@@ -223,9 +223,15 @@ Capybara::Screenshot.s3_configuration = {
     secret_access_key: "my_secret_access_key",
     region: "eu-central-1"
   },
-  bucket_name: "my_screenshots"
+  bucket_name: "my_screenshots",
+  # Optionally: Specify the bucket location to save a request
+  bucket_location: "eu-central-1"
 }
 ```
+
+The access key used for S3 uploads need to have at least the `s3:PutObject` permission.
+
+**Note**: If you do not provide the `bucket_location` configuration option, additionally the `s3:GetBucketLocation` permission is required on the bucket for uploads to succeed.
 
 It is also possible to specify the object parameters such as acl.
 Configure the capybara-screenshot with these options in this way:

--- a/lib/capybara-screenshot/s3_saver.rb
+++ b/lib/capybara-screenshot/s3_saver.rb
@@ -11,6 +11,7 @@ module Capybara
         @saver = saver
         @s3_client = s3_client
         @bucket_name = bucket_name
+        @bucket_location = options[:bucket_location]
         @key_prefix = options[:key_prefix]
         @object_configuration = object_configuration
       end
@@ -49,7 +50,7 @@ module Capybara
                 object_payload
             )
 
-            s3_region = s3_client.get_bucket_location(bucket: bucket_name).location_constraint
+            s3_region = bucket_location || determine_bucket_location
 
             send("#{type}_path=", "https://#{bucket_name}.s3-#{s3_region}.amazonaws.com/#{s3_upload_path}")
           end
@@ -68,8 +69,16 @@ module Capybara
       attr_reader :saver,
                   :s3_client,
                   :bucket_name,
+                  :bucket_location,
                   :object_configuration
                   :key_prefix
+
+      ##
+      # Reads the bucket location using a S3 get_bucket_location request.
+      # Requires the +s3:GetBucketLocation+ policy.
+      def determine_bucket_location
+        s3_client.get_bucket_location(bucket: bucket_name).location_constraint
+      end
 
       def save_and
         saver.save

--- a/lib/capybara-screenshot/s3_saver.rb
+++ b/lib/capybara-screenshot/s3_saver.rb
@@ -11,7 +11,7 @@ module Capybara
         @saver = saver
         @s3_client = s3_client
         @bucket_name = bucket_name
-        @bucket_location = options[:bucket_location]
+        @bucket_host = options[:bucket_host]
         @key_prefix = options[:key_prefix]
         @object_configuration = object_configuration
       end
@@ -50,9 +50,9 @@ module Capybara
                 object_payload
             )
 
-            s3_region = bucket_location || determine_bucket_location
+            host = bucket_host || determine_bucket_host
 
-            send("#{type}_path=", "https://#{bucket_name}.s3-#{s3_region}.amazonaws.com/#{s3_upload_path}")
+            send("#{type}_path=", "https://#{host}/#{s3_upload_path}")
           end
         end
       end
@@ -69,15 +69,16 @@ module Capybara
       attr_reader :saver,
                   :s3_client,
                   :bucket_name,
-                  :bucket_location,
+                  :bucket_host,
                   :object_configuration
                   :key_prefix
 
       ##
       # Reads the bucket location using a S3 get_bucket_location request.
       # Requires the +s3:GetBucketLocation+ policy.
-      def determine_bucket_location
-        s3_client.get_bucket_location(bucket: bucket_name).location_constraint
+      def determine_bucket_host
+        s3_region = s3_client.get_bucket_location(bucket: bucket_name).location_constraint
+        "#{bucket_name}.s3-#{s3_region}.amazonaws.com"
       end
 
       def save_and

--- a/spec/unit/s3_saver_spec.rb
+++ b/spec/unit/s3_saver_spec.rb
@@ -105,16 +105,16 @@ describe Capybara::Screenshot::S3Saver do
       allow(saver).to receive(:save)
     end
 
-    context 'providing a bucket_location' do
-      let(:options) { { bucket_location: 'some other location' } }
+    context 'providing a bucket_host' do
+      let(:options) { { bucket_host: 'some other location' } }
   
       it 'does not request the bucket location' do
         screenshot_path = '/baz/bim.jpg'
-  
+
         screenshot_file = double('screenshot_file')
-  
-        expect(s3_saver).not_to receive(:determine_bucket_location)
-  
+
+        expect(s3_saver).not_to receive(:determine_bucket_host)
+
         s3_saver.save
       end
     end
@@ -140,7 +140,7 @@ describe Capybara::Screenshot::S3Saver do
         body: html_file
       )
 
-      expect(s3_saver).to receive(:determine_bucket_location).and_call_original
+      expect(s3_saver).to receive(:determine_bucket_host).and_call_original
 
       s3_saver.save
     end

--- a/spec/unit/s3_saver_spec.rb
+++ b/spec/unit/s3_saver_spec.rb
@@ -5,10 +5,11 @@ describe Capybara::Screenshot::S3Saver do
   let(:saver) { double('saver') }
   let(:bucket_name) { double('bucket_name') }
   let(:s3_object_configuration) { {} }
+  let(:options) { {} }
   let(:s3_client) { double('s3_client') }
   let(:key_prefix){ "some/path/" }
 
-  let(:s3_saver) { described_class.new(saver, s3_client, bucket_name, s3_object_configuration) }
+  let(:s3_saver) { described_class.new(saver, s3_client, bucket_name, s3_object_configuration, options) }
   let(:s3_saver_with_key_prefix) { described_class.new(saver, s3_client, bucket_name, s3_object_configuration, key_prefix: key_prefix) }
 
   let(:region) { double('region') }
@@ -104,6 +105,20 @@ describe Capybara::Screenshot::S3Saver do
       allow(saver).to receive(:save)
     end
 
+    context 'providing a bucket_location' do
+      let(:options) { { bucket_location: 'some other location' } }
+  
+      it 'does not request the bucket location' do
+        screenshot_path = '/baz/bim.jpg'
+  
+        screenshot_file = double('screenshot_file')
+  
+        expect(s3_saver).not_to receive(:determine_bucket_location)
+  
+        s3_saver.save
+      end
+    end
+
     it 'calls save on the underlying saver' do
       expect(saver).to receive(:save)
 
@@ -124,6 +139,8 @@ describe Capybara::Screenshot::S3Saver do
         key: 'bar.html',
         body: html_file
       )
+
+      expect(s3_saver).to receive(:determine_bucket_location).and_call_original
 
       s3_saver.save
     end


### PR DESCRIPTION
Intended to replace PR #250

TL;DR there's no universal S3 bucket hostname that
all S3 buckets support; some buckets need to be
accessed via bucketname.s3.amazonaws.com, while
others require bucketname.s3-us-east-1.s3.amazonaws.com.
The best way to support these different use cases
is to simply allow the user to specify this via
the `bucket_host` option introduced by this PR.

/cc @oliverguenther

See this comment for more details:

https://github.com/mattheworiordan/capybara-screenshot/pull/250#issuecomment-475398605