### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/capybara-screenshot.gemspec
+++ b/capybara-screenshot.gemspec
@@ -12,6 +12,12 @@ Gem::Specification.new do |s|
   s.summary     = %q{Automatically create snapshots when Cucumber steps fail with Capybara and Rails}
   s.description = %q{When a Cucumber step fails, it is useful to create a screenshot image and HTML file of the current page}
   s.license     = 'MIT'
+  s.metadata    = {
+    "bug_tracker_uri"   => "https://github.com/mattheworiordan/capybara-screenshot/issues",
+    "changelog_uri"     => "https://github.com/mattheworiordan/capybara-screenshot/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/capybara-screenshot/#{s.version}",
+    "source_code_uri"   => "https://github.com/mattheworiordan/capybara-screenshot/tree/v#{s.version}",
+  }
 
   s.rubyforge_project = "capybara-screenshot"
 


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/capybara-screenshot), via the Rubygems API, and the `gem` and `bundle` command-line tools with the next release.