### PR TITLE
Add support for cuprite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ capybara-screenshot gem
 #### Capture a screenshot for every test failure automatically!
 
 `capybara-screenshot` used with [Capybara](https://github.com/jnicklas/capybara) alongside [Cucumber](http://cukes.info/), [Rspec](https://www.relishapp.com/rspec) or [Minitest](https://github.com/seattlerb/minitest), will capture a screenshot for each failure in your test suite. Associated screenshot and HTML file
-of the failed page (when using [capybara-webkit](https://github.com/thoughtbot/capybara-webkit), [Selenium](http://seleniumhq.org/) or [poltergeist](https://github.com/jonleighton/poltergeist)) is saved into `$APPLICATION_ROOT/tmp/capybara`.
+of the failed page (when using [capybara-webkit](https://github.com/thoughtbot/capybara-webkit), [Selenium](http://seleniumhq.org/), [poltergeist](https://github.com/jonleighton/poltergeist) or [cuprite](https://github.com/machinio/cuprite)) is saved into `$APPLICATION_ROOT/tmp/capybara`.
 
 Available screenshots for each test failure is incredibly helpful for diagnosing problems quickly in your failing steps. You have the ability to view screenshots (when applicable) and source code at the time of each failure.
 
@@ -130,7 +130,7 @@ This will cause Capybara to add `<base>http://localhost:3000</base>` to the HTML
 rails s -p 3000
 ```
 
-Now when you open the page, you should have something that looks much better.  You can leave this setup in place and use the default HTML pages when you don't care about the presentation, or start the rails server when you need something better looking.  
+Now when you open the page, you should have something that looks much better.  You can leave this setup in place and use the default HTML pages when you don't care about the presentation, or start the rails server when you need something better looking.
 
 Driver configuration
 --------------------

--- a/capybara-screenshot.gemspec
+++ b/capybara-screenshot.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/mattheworiordan/capybara-screenshot/tree/v#{s.version}",
   }
 
-  s.rubyforge_project = "capybara-screenshot"
-
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("1.9")
     s.add_dependency 'capybara', ['>= 1.0', '< 2']
   elsif Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.2.2")

--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -190,9 +190,13 @@ Capybara::Screenshot.class_eval do
       :not_supported
     end
   end
-  
+
   register_driver(:apparition) do |driver, path|
     driver.save_screenshot(path)
+  end
+
+  register_driver(:cuprite) do |driver, path|
+    driver.render(path, :full => true)
   end
 end
 

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -298,6 +298,19 @@ describe Capybara::Screenshot::Saver do
     end
   end
 
+  describe "with cuprite driver" do
+    before do
+      allow(capybara_mock).to receive(:current_driver).and_return(:cuprite)
+    end
+
+    it 'saves driver render with :full => true' do
+      expect(driver_mock).to receive(:render).with(screenshot_path, {:full => true})
+
+      saver.save
+      expect(saver).to be_screenshot_saved
+    end
+  end
+
   describe "with webkit driver" do
     before do
       allow(capybara_mock).to receive(:current_driver).and_return(:webkit)


### PR DESCRIPTION
[cuprite](https://github.com/machinio/cuprite) is a modern pure-ruby driver for Chrome headless, which replaces the selenium + chromedriver combo. It supports screenshots the default capybara screenshot method (so it already works with `capybara-screenshot`) but produces partial screenshots and warnings in the console (as expected):
```
capybara-screenshot could not detect a screenshot driver for 'cuprite'. Saving with default with unknown results.
```

So as it's easy I added support for the `cuprite` driver with the "full" option to get complete screenshot and no more warning. It works fine in my project and I also added specs :tada:

Thank you for this project and let me know if I can do anything else ;)