### PR TITLE
Add support for billy's selenium drivers

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -172,6 +172,11 @@ Capybara::Screenshot.class_eval do
     driver.render(path, :full => true)
   end
 
+  register_driver :selenium_billy, &selenium_block
+  register_driver :selenium_headless_billy, &selenium_block
+  register_driver :selenium_chrome_billy, &selenium_block
+  register_driver :selenium_chrome_headless_billy, &selenium_block
+
   webkit_block = proc do |driver, path|
     if driver.respond_to?(:save_screenshot)
       driver.save_screenshot(path, webkit_options)

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -298,6 +298,66 @@ describe Capybara::Screenshot::Saver do
     end
   end
 
+  describe "with selenium_billy driver" do
+    before do
+      allow(capybara_mock).to receive(:current_driver).and_return(:selenium_billy)
+    end
+
+    it 'saves via browser' do
+      browser_mock = double('browser')
+      expect(driver_mock).to receive(:browser).and_return(browser_mock)
+      expect(browser_mock).to receive(:save_screenshot).with(screenshot_path)
+
+      saver.save
+      expect(saver).to be_screenshot_saved
+    end
+  end
+
+  describe "with selenium_headless_billy driver" do
+    before do
+      allow(capybara_mock).to receive(:current_driver).and_return(:selenium_headless_billy)
+    end
+
+    it 'saves via browser' do
+      browser_mock = double('browser')
+      expect(driver_mock).to receive(:browser).and_return(browser_mock)
+      expect(browser_mock).to receive(:save_screenshot).with(screenshot_path)
+
+      saver.save
+      expect(saver).to be_screenshot_saved
+    end
+  end
+
+  describe "with selenium_chrome_billy driver" do
+    before do
+      allow(capybara_mock).to receive(:current_driver).and_return(:selenium_chrome_billy)
+    end
+
+    it 'saves via browser' do
+      browser_mock = double('browser')
+      expect(driver_mock).to receive(:browser).and_return(browser_mock)
+      expect(browser_mock).to receive(:save_screenshot).with(screenshot_path)
+
+      saver.save
+      expect(saver).to be_screenshot_saved
+    end
+  end
+
+  describe "with selenium_chrome_headless_billy driver" do
+    before do
+      allow(capybara_mock).to receive(:current_driver).and_return(:selenium_chrome_headless_billy)
+    end
+
+    it 'saves via browser' do
+      browser_mock = double('browser')
+      expect(driver_mock).to receive(:browser).and_return(browser_mock)
+      expect(browser_mock).to receive(:save_screenshot).with(screenshot_path)
+
+      saver.save
+      expect(saver).to be_screenshot_saved
+    end
+  end
+
   describe "with cuprite driver" do
     before do
       allow(capybara_mock).to receive(:current_driver).and_return(:cuprite)


### PR DESCRIPTION
`#109` supported billy, but only added poltergeist driver. This patch supports more drivers(related with selenium).

Ref: https://github.com/oesmith/puffing-billy/blob/fc12d19cfa27182463c5c300acacd517a557d339/lib/billy/browsers/capybara.rb#L48-L96