### PR TITLE
Change apparition driver to create full size screenshots

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -192,7 +192,7 @@ Capybara::Screenshot.class_eval do
   end
 
   register_driver(:apparition) do |driver, path|
-    driver.save_screenshot(path)
+    driver.save_screenshot(path, :full => true)
   end
 
   register_driver(:cuprite) do |driver, path|

--- a/spec/unit/saver_spec.rb
+++ b/spec/unit/saver_spec.rb
@@ -298,6 +298,19 @@ describe Capybara::Screenshot::Saver do
     end
   end
 
+  describe "with apparition driver" do
+    before do
+      allow(capybara_mock).to receive(:current_driver).and_return(:apparition)
+    end
+
+    it 'saves driver render with :full => true' do
+      expect(driver_mock).to receive(:save_screenshot).with(screenshot_path, {:full => true})
+
+      saver.save
+      expect(saver).to be_screenshot_saved
+    end
+  end
+
   describe "with cuprite driver" do
     before do
       allow(capybara_mock).to receive(:current_driver).and_return(:cuprite)


### PR DESCRIPTION
apparition supports taking full size screenshots since the very first commit (see https://github.com/twalpole/apparition/blob/ac6f66162de7e1290d53b70d391ced890ec6a430/README.md?plain=1#L64-L66), so backwards compatibility should be no problem.

It noticed that there was no test for the apparition driver, so I added one.