### PR TITLE
If no driver matching capybara.current_driver can be found, fall back to looking up by class

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -148,9 +148,11 @@ Capybara::Screenshot.class_eval do
     driver.render(path)
   end
 
-  register_driver(:rack_test) do |driver, path|
+  block = proc do |driver, path|
     :not_supported
   end
+  register_driver(:rack_test, &block)
+  register_driver(:'Rack::Test', &block)
 
   register_driver(:mechanize) do |driver, path|
     :not_supported
@@ -163,6 +165,7 @@ Capybara::Screenshot.class_eval do
   register_driver :selenium, &selenium_block
   register_driver :selenium_chrome, &selenium_block
   register_driver :selenium_chrome_headless, &selenium_block
+  register_driver :'Capybara::Selenium::Driver', &selenium_block
 
   register_driver(:poltergeist) do |driver, path|
     driver.render(path, :full => true)
@@ -195,9 +198,11 @@ Capybara::Screenshot.class_eval do
     driver.save_screenshot(path)
   end
 
-  register_driver(:cuprite) do |driver, path|
-    driver.render(path, :full => true)
+  block = proc do |driver, path|
+    driver.render(path, full: true)
   end
+  register_driver(:cuprite, &block)
+  register_driver(:'Capybara::Cuprite::Driver', &block)
 end
 
 # Register filename prefix formatters

--- a/spec/support/general_helpers.rb
+++ b/spec/support/general_helpers.rb
@@ -1,0 +1,31 @@
+# Copied from activesupport/lib/active_support/inflector/methods.rb
+def constantize(camel_cased_word)
+  names = camel_cased_word.split("::".freeze)
+
+  # Trigger a built-in NameError exception including the ill-formed constant in the message.
+  Object.const_get(camel_cased_word) if names.empty?
+
+  # Remove the first blank element in case of '::ClassName' notation.
+  names.shift if names.size > 1 && names.first.empty?
+
+  names.inject(Object) do |constant, name|
+    if constant == Object
+      constant.const_get(name)
+    else
+      candidate = constant.const_get(name)
+      next candidate if constant.const_defined?(name, false)
+      next candidate unless Object.const_defined?(name)
+
+      # Go down the ancestors to check if it is owned directly. The check
+      # stops when we reach Object or the end of ancestors tree.
+      constant = constant.ancestors.inject(constant) do |const, ancestor|
+        break const    if ancestor == Object
+        break ancestor if ancestor.const_defined?(name, false)
+        const
+      end
+
+      # owner is in Object, so raise
+      constant.const_get(name, false)
+    end
+  end
+end


### PR DESCRIPTION
(page.driver.class.to_sym)

This allows it to still find the driver even if they registered it with Capybara.register_driver using an alias name that isn't known to Capybara::Screenshot. See #284.