### PR TITLE
Support headless firefox screenshots

### DIFF
--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -161,6 +161,7 @@ Capybara::Screenshot.class_eval do
   end
 
   register_driver :selenium, &selenium_block
+  register_driver :selenium_headless, &selenium_block
   register_driver :selenium_chrome, &selenium_block
   register_driver :selenium_chrome_headless, &selenium_block
 


### PR DESCRIPTION
This was probably just an ommission. It's quite useful to get screenshots when running failing headless specs.