### PR TITLE
Manually save screenshots with custom prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,21 @@ Anywhere the Capybara DSL methods (visit, click etc.) are available so too are t
 
 ```ruby
 screenshot_and_save_page
+
+# with custom prefix
+screenshot_and_save_page(filename_prefix: 'custom_prefix')
+
+# image only, with custom prefix:
+screenshot_and_save_page(filename_prefix: 'custom_prefix', save_html: false)
 ```
 
 Or for screenshot only, which will automatically open the image:
 
 ```ruby
 screenshot_and_open_image
+
+# with custom prefix
+screenshot_and_open_image(filename_prefix: 'custom_prefix')
 ```
 
 These are just calls on the main library methods:

--- a/lib/capybara-screenshot.rb
+++ b/lib/capybara-screenshot.rb
@@ -29,17 +29,19 @@ module Capybara
       RSpec.add_link_to_screenshot_for_failed_examples = value
     end
 
-    def self.screenshot_and_save_page
-      saver = new_saver(Capybara, Capybara.page)
+    def self.screenshot_and_save_page(filename_prefix: nil, save_html: true)
+      saver = new_saver(Capybara, Capybara.page, save_html, filename_prefix)
       if saver.save
         {:html => saver.html_path, :image => saver.screenshot_path}
+      elsif !save_html
+        warn 'WARN: no screenshot has been saved. You should configure the driver used by Capybara to save images.'
       end
     end
 
-    def self.screenshot_and_open_image
+    def self.screenshot_and_open_image(filename_prefix: nil)
       require "launchy"
 
-      saver = new_saver(Capybara, Capybara.page, false)
+      saver = new_saver(Capybara, Capybara.page, false, filename_prefix)
       if saver.save
         Launchy.open saver.screenshot_path
         {:html => nil, :image => saver.screenshot_path}

--- a/lib/capybara-screenshot/capybara.rb
+++ b/lib/capybara-screenshot/capybara.rb
@@ -19,12 +19,12 @@ module Capybara
     # Adds class methods to Capybara module and gets mixed into
     # the current scope during Cucumber and RSpec tests
 
-    def screenshot_and_save_page
-      Capybara::Screenshot.screenshot_and_save_page
+    def screenshot_and_save_page(filename_prefix: nil, save_html: true)
+      Capybara::Screenshot.screenshot_and_save_page(filename_prefix: filename_prefix, save_html: save_html)
     end
 
-    def screenshot_and_open_image
-      Capybara::Screenshot.screenshot_and_open_image
+    def screenshot_and_open_image(filename_prefix: nil)
+      Capybara::Screenshot.screenshot_and_open_image(filename_prefix: filename_prefix)
     end
   end
 

--- a/spec/cucumber/cucumber_spec.rb
+++ b/spec/cucumber/cucumber_spec.rb
@@ -61,6 +61,26 @@ describe "Using Capybara::Screenshot with Cucumber" do
     expect('tmp/my_screenshot.html').to have_file_content('This is a different page')
   end
 
+  it 'saves a screenshot with custom prefix' do
+    run_case(<<-CUCUMBER)
+      Feature: Custom prefix
+        Scenario: Screenshot with custom prefix
+          Given I visit "/"
+          And I save the page with a custom prefix
+    CUCUMBER
+    expect('tmp/custom_prefix.html').to have_file_content('This is the root page')
+  end
+
+  it 'displays a warning when a screenshot without HTML is asked but not saved' do
+    run_case(<<-CUCUMBER)
+      Feature: Custom prefix
+        Scenario: Empty screenshot
+          Given I visit "/different_page"
+          And I take a screenshot which is not saved
+    CUCUMBER
+    expect(last_command_started.output).to include('WARN: no screenshot has been saved.')
+  end
+
   context 'pruning' do
     before do
       create_screenshot_for_pruning

--- a/spec/cucumber/step_definitions/step_definitions.rb
+++ b/spec/cucumber/step_definitions/step_definitions.rb
@@ -16,3 +16,11 @@ end
 Then(/^I trigger an unhandled exception/) do
   raise "you can't handle me"
 end
+
+Then(/^I save the page with a custom prefix$/) do
+  screenshot_and_save_page filename_prefix: 'custom_prefix'
+end
+
+Then(/^I take a screenshot which is not saved$/) do
+  screenshot_and_save_page save_html: false
+end


### PR DESCRIPTION
Hello !

I'm reopening https://github.com/mattheworiordan/capybara-screenshot/pull/256:

I used to generate some screenshots for a documentation system, so I needed to customize the file names. This PR adds updates `screenshot_and_save_page` and `screenshot_and_open_image` with two additional parameters: `prefix` (to specify a base file name) and `html` (to only save a picture when `false`)

I still use this feature from time to time.